### PR TITLE
Psf fixes

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -252,6 +252,10 @@ class HAL(PluginPrototype):
 
                 self._active_planes.append(this_bin)
 
+        if self._likelihood_model:
+
+            self.set_model( self._likelihood_model )
+
     def display(self, verbose=False):
         """
         Prints summary of the current object content.

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -166,12 +166,13 @@ class HAL(PluginPrototype):
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
-        
+
             #Only set up PSF convolutors for active bins.
             if bin_id in self._active_planes:
-                self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf, self._flat_sky_projection)
+                self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf,
+                                                              self._flat_sky_projection)
 
- 
+
     def _compute_likelihood_biases(self):
 
         for bin_label in self._maptree:
@@ -567,7 +568,7 @@ class HAL(PluginPrototype):
         for pts_id in range(n_point_sources):
 
             this_conv_src = self._convolved_point_sources[pts_id]
-            
+
             expectation_per_transit = this_conv_src.get_source_map(energy_bin_id,
                                                                    tag=None,
                                                                    psf_integration_method=self._psf_integration_method)

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -166,8 +166,11 @@ class HAL(PluginPrototype):
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
+        
+            #Only set up PSF convolutors for active bins.
             if bin_id in self._active_planes:
-               self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf, self._flat_sky_projection)
+                self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf, self._flat_sky_projection)
+
  
     def _compute_likelihood_biases(self):
 

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -166,8 +166,9 @@ class HAL(PluginPrototype):
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
-            self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf, self._flat_sky_projection)
-
+            if bin_id in self._active_planes:
+               self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf, self._flat_sky_projection)
+ 
     def _compute_likelihood_biases(self):
 
         for bin_label in self._maptree:
@@ -563,7 +564,7 @@ class HAL(PluginPrototype):
         for pts_id in range(n_point_sources):
 
             this_conv_src = self._convolved_point_sources[pts_id]
-
+            
             expectation_per_transit = this_conv_src.get_source_map(energy_bin_id,
                                                                    tag=None,
                                                                    psf_integration_method=self._psf_integration_method)

--- a/hawc_hal/psf_fast/psf_convolutor.py
+++ b/hawc_hal/psf_fast/psf_convolutor.py
@@ -32,7 +32,7 @@ class PSFConvolutor(object):
 
         self._kernel = psf_stamp[yoff:-yoff, xoff:-xoff]
 
-        assert np.isclose(self._kernel.sum(), 1.0, rtol=1e-2), "Failed to generate proper kernel normalization"
+        assert np.isclose(self._kernel.sum(), 1.0, rtol=1e-2), "Failed to generate proper kernel normalization: got _kernel.sum() = %f; expected 1.0+-0.01." % self._kernel.sum()
 
         # Renormalize to exactly 1
         self._kernel = self._kernel / self._kernel.sum()


### PR DESCRIPTION
Only set up PSF convolutors for active bins to avoid HAL crashing due to  invalid PSFs. 

