### PR TITLE
Arbitrary ROIs defined as Healpix maps

### DIFF
--- a/hawc_hal/region_of_interest/__init__.py
+++ b/hawc_hal/region_of_interest/__init__.py
@@ -1,5 +1,5 @@
-from healpix_cone_roi import HealpixConeROI, HealpixROIBase
-from healpix_map_roi import HealpixMapROI
+from hawc_hal.region_of_interest.healpix_cone_roi import HealpixConeROI, HealpixROIBase
+from hawc_hal.region_of_interest.healpix_map_roi import HealpixMapROI
 
 
 def get_roi_from_dict(dictionary):

--- a/hawc_hal/region_of_interest/__init__.py
+++ b/hawc_hal/region_of_interest/__init__.py
@@ -1,4 +1,5 @@
 from healpix_cone_roi import HealpixConeROI, HealpixROIBase
+from healpix_map_roi import HealpixMapROI
 
 
 def get_roi_from_dict(dictionary):

--- a/hawc_hal/region_of_interest/healpix_map_roi.py
+++ b/hawc_hal/region_of_interest/healpix_map_roi.py
@@ -1,0 +1,162 @@
+import numpy as np
+import astropy.units as u
+import healpy as hp
+from healpix_roi_base import HealpixROIBase, _RING, _NESTED
+from astropy.io import fits
+
+from astromodels.core.sky_direction import SkyDirection
+
+from ..healpix_handling import radec_to_vec
+from ..flat_sky_projection import FlatSkyProjection
+
+
+def _get_radians(my_angle):
+
+    if isinstance(my_angle, u.Quantity):
+
+        my_angle_radians = my_angle.to(u.rad).value
+
+    else:
+
+        my_angle_radians = np.deg2rad(my_angle)
+
+    return my_angle_radians
+
+
+class HealpixMapROI(HealpixROIBase):
+
+    def __init__(self, model_radius, map=None, file = None, *args, **kwargs):
+        """
+        A cone Region of Interest defined by a center and a radius.
+
+        Examples:
+
+            ROI centered on (R.A., Dec) = (1.23, 4.56) in J2000 ICRS coordinate system, with a radius of 5 degrees:
+
+            > roi = HealpixConeROI(5.0, ra=1.23, dec=4.56)
+
+            ROI centered on (L, B) = (1.23, 4.56) (Galactic coordiantes) with a radius of 30 arcmin:
+
+            > roi = HealpixConeROI(30.0 * u.arcmin, l=1.23, dec=4.56)
+
+        :param data_radius: radius of the cone. Either an astropy.Quantity instance, or a float, in which case it is assumed
+        to be the radius in degrees
+        :param model_radius: radius of the model cone. Either an astropy.Quantity instance, or a float, in which case it
+        is assumed to be the radius in degrees
+        :param args: arguments for the SkyDirection class of astromodels
+        :param kwargs: keywords for the SkyDirection class of astromodels
+        """
+ 
+        assert file is not kwargs or map is  not None, "Must supply either healpix map or fits file to create HealpixMapROI"
+
+
+        self._center = SkyDirection(*args, **kwargs)
+
+        self._model_radius_radians = _get_radians(model_radius)
+        
+        if file is not None:
+            self._filename = file
+            map =  hp.fitsfunc.read_map(self._filename)
+        elif map is not None:
+            map = map
+            self._filename = None
+
+        self._maps = {}
+
+        self._original_nside = hp.npix2nside( map.shape[0] )
+        self._maps[self._original_nside] = map
+
+        self._threshold  = 0.5
+        if "threshold" in kwargs:
+            self._threshold = kwargs["threshold"]
+
+
+    def to_dict(self):
+
+        ra, dec = self.ra_dec_center
+
+        s = {'ROI type': type(self).__name__.split(".")[-1],
+             'ra': ra,
+             'dec': dec,
+             'model_radius_deg': np.rad2deg(self._model_radius_radians),
+             'map': self._map,
+             'threshold': self._threshold,
+             'file': self._filename }
+
+        return s
+
+    @classmethod
+    def from_dict(cls, data):
+
+        return cls(data['data_radius_deg'], threshold = data['threshold'], map = data['map'], ra=data['ra'], dec=data['dec'], file=data['file'])
+
+    def __str__(self):
+
+        s = ("%s: Center (R.A., Dec) = (%.3f, %.3f), model radius: %.3f deg, threshold = %.2f" %
+              (type(self).__name__, self.ra_dec_center[0], self.ra_dec_center[1],
+               self.model_radius.to(u.deg).value, self._threshold))
+
+        if self._filename is not None: 
+            s  =  "%s,  data ROI from %s" %  (s, self._filename)
+            
+        return s
+
+    def display(self):
+
+        print(self)
+
+    @property
+    def ra_dec_center(self):
+
+        return self._get_ra_dec()
+
+    @property
+    def model_radius(self):
+        return self._model_radius_radians * u.rad
+
+    @property
+    def threshold(self):
+        return self._threshold
+
+    def _get_ra_dec(self):
+
+        lon, lat = self._center.get_ra(), self._center.get_dec()
+
+        return lon, lat
+
+    def _get_healpix_vec(self):
+
+        lon, lat = self._get_ra_dec()
+
+        vec = radec_to_vec(lon, lat)
+
+        return vec
+
+    def _active_pixels(self, nside, ordering):
+
+        vec = self._get_healpix_vec()
+
+        nest = ordering is _NESTED
+            
+        if not nside in self._maps:
+          self._maps[nside] = hp.ud_grade(self._maps[self._original_nside], nside_out=nside)
+
+        pixels_inside_map = np.where( self._maps[ nside ] >= self._threshold )[0]
+
+        return pixels_inside_map
+
+    def get_flat_sky_projection(self, pixel_size_deg):
+
+        # Decide side for image
+
+        # Compute number of pixels, making sure it is going to be even (by approximating up)
+        npix_per_side = 2 * int(np.ceil(np.rad2deg(self._model_radius_radians) / pixel_size_deg))
+
+        # Get lon, lat of center
+        ra, dec = self._get_ra_dec()
+
+        # This gets a list of all RA, Decs for an AIT-projected image of npix_per_size x npix_per_side
+        flat_sky_proj = FlatSkyProjection(ra, dec, pixel_size_deg, npix_per_side, npix_per_side)
+
+        return flat_sky_proj
+

--- a/hawc_hal/region_of_interest/healpix_map_roi.py
+++ b/hawc_hal/region_of_interest/healpix_map_roi.py
@@ -24,7 +24,7 @@ class HealpixMapROI(HealpixROIBase):
 
             > roi = HealpixMapROI(5.0, ra=1.23, dec=4.56, file = "myROI.fits" )
 
-            Model map centered on (L, B) = (1.23, 4.56) (Galactic coordiantes) 
+            Model map centered on (L, B) = (1.23, 4.56) (Galactic coordiantes)
             with a radius of 30 arcmin, ROI defined on-the-fly in healpix map:
 
             > roi = HealpixMapROI(30.0 * u.arcmin, l=1.23, dec=4.56, map = my_roi)
@@ -38,7 +38,7 @@ class HealpixMapROI(HealpixROIBase):
         :param kwargs: keywords for the SkyDirection class of astromodels
         """
  
-        assert file is not None or map is  not None, "Must supply either healpix map or fitsfile to create HealpixMapROI"
+        assert roifile is not None or roimap is not None, "Must supply either healpix map or fitsfile to create HealpixMapROI"
 
         self._center = SkyDirection(*args, **kwargs)
 
@@ -99,9 +99,9 @@ class HealpixMapROI(HealpixROIBase):
     @classmethod
     def from_dict(cls, data):
 
-        return cls(data['model_radius_deg'], threshold = data['threshold'], 
-                    roimap = data['roimap'], ra=data['ra'], 
-                    dec=data['dec'], roifile=data['roifile'])
+        return cls(data['model_radius_deg'], threshold=data['threshold'],
+                   roimap=data['roimap'], ra=data['ra'],
+                   dec=data['dec'], roifile=data['roifile'])
 
     def __str__(self):
 
@@ -138,9 +138,9 @@ class HealpixMapROI(HealpixROIBase):
         return lon, lat
 
     def _active_pixels(self, nside, ordering):
-            
+
         if not nside in self._roimaps:
-          self._roimaps[nside] = hp.ud_grade(self._maps[self._original_nside], nside_out=nside)
+          self._roimaps[nside] = hp.ud_grade(self._roimaps[self._original_nside], nside_out=nside)
 
         pixels_inside_roi = np.where(self._roimaps[nside] >= self._threshold)[0]
 

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -32,14 +32,14 @@ def test_rois():
                      dec=dec)
 
   m = np.zeros(hp.nside2npix(NSIDE))
-  vec = Sky2Vec( ra, dec )
+  vec = Sky2Vec(ra, dec)
   m[hp.query_disc(NSIDE, vec, (data_radius*u.degree).to(u.radian).value, inclusive=False)] = 1
 
   hp.fitsfunc.write_map("roitemp.fits" , m, nest=False, coord="C", partial=False, overwrite=True )  
 
 
-  map_roi = HealpixMapROI( ra= ra, dec=dec, model_radius=model_radius, map=m)
-  fits_roi = HealpixMapROI( ra= ra, dec=dec, model_radius=model_radius, file="roitemp.fits")
+  map_roi = HealpixMapROI(ra= ra, dec=dec, model_radius=model_radius, roimap=m)
+  fits_roi = HealpixMapROI(ra= ra, dec=dec, model_radius=model_radius, roifile="roitemp.fits")
 
   assert np.all( cone_roi.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
   assert np.all( fits_roi.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -1,0 +1,61 @@
+import pytest
+from hawc_hal import HealpixConeROI
+from hawc_hal import HealpixMapROI
+from hawc_hal.region_of_interest import get_roi_from_dict
+import healpy as hp
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+import os
+
+
+def Sky2Vec( ra, dec ):
+  c = SkyCoord( frame = "icrs", ra=ra*u.degree, dec=dec*u.degree )
+  theta = (90.0*u.degree-c.dec).to(u.radian).value
+  phi = c.ra.to(u.radian).value
+  vec = hp.pixelfunc.ang2vec(theta, phi)
+  return vec
+
+NSIDE=512
+
+def test_rois():
+
+  #test to make sure ConeROI and MapROI with a simple, circular active region return the same active pixels.
+
+  ra, dec = 100, 30
+  data_radius = 10
+  model_radius = 15
+
+  cone_roi = HealpixConeROI(data_radius=data_radius,
+                     model_radius=model_radius,
+                     ra=ra,
+                     dec=dec)
+
+  m = np.zeros(hp.nside2npix(NSIDE))
+  vec = Sky2Vec( ra, dec )
+  m[hp.query_disc(NSIDE, vec, (data_radius*u.degree).to(u.radian).value, inclusive=False)] = 1
+
+  hp.fitsfunc.write_map("roitemp.fits" , m, nest=False, coord="C", partial=False, overwrite=True )  
+
+
+  map_roi = HealpixMapROI( ra= ra, dec=dec, model_radius=model_radius, map=m)
+  fits_roi = HealpixMapROI( ra= ra, dec=dec, model_radius=model_radius, file="roitemp.fits")
+
+  assert np.all( cone_roi.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
+  assert np.all( fits_roi.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
+
+  os.remove( "roitemp.fits" )
+  #test that all is still good after saving the ROIs to dictionaries and restoring.
+  cone_dict =  cone_roi.to_dict()
+  map_dict =  map_roi.to_dict()
+  fits_dict =  fits_roi.to_dict()
+  
+  cone_roi2  = get_roi_from_dict( cone_dict )
+  map_roi2  = get_roi_from_dict( map_dict )
+  fits_roi2  = get_roi_from_dict( fits_dict )
+  
+  assert np.all( cone_roi2.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
+  assert np.all( fits_roi2.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
+  assert np.all( map_roi2.active_pixels(NSIDE) == map_roi.active_pixels(NSIDE))
+  
+  


### PR DESCRIPTION
I added a new `HealpixMapROI` class which supports arbitrarily shaped ROIs via healpix maps. The maps can be read in from a fits file or created in the analysis script and passed as a list.

The user still  has to supply a center position and radius for the model map, as  for `HealpixConeROI`. A warning is printed if the ROI is not fully contained in the model 'cone'.

In case the user-specified healpix map has a different NSIDE than the data maps, `hp.pixelfunc.ud_grade` is used to re-sample the ROI map to the same NSIDE as the data map.

Some tests have been added to verify that the same pixels are selected by a cone ROI and by a map ROI with the same circular  active region.

Non-circular ROIs are useful for example to cut out bright nearby sources or galactic diffuse emission. 
