### PR TITLE
Model residual maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ fig.savefig("hal_corner_plot.png")
 ### Convert ROOT maptree to hdf5 maptree
 
 ```python
-from hawc_hal.map_tree import map_tree_factory
+from hawc_hal.maptree import map_tree_factory
 from hawc_hal import HealpixConeROI
 
 root_map_tree = "maptree_1024.root" # path to your ROOT maptree

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -891,7 +891,6 @@ class HAL(PluginPrototype):
         """
         This writes either a model map or a residual map, depending on which one is preferred
         """
-
         which = which.lower()
         assert which in [ 'model', 'residual' ]
 
@@ -910,7 +909,7 @@ class HAL(PluginPrototype):
                 bin_map=self._get_model_map(plane_id, n_pt, n_ext)
                 fake_data=bin_map+bkg
             else:
-                bin_map=data_analysis_bin.observation
+                bin_map=data_analysis_bin.observation_map
                 fake_data=bin_map-bkg
 
 
@@ -933,7 +932,7 @@ class HAL(PluginPrototype):
 
         #save the file
         new_map_tree = MapTree(map_analysis_bins, self._roi)
-        new_map.write(filename)
+        new_map_tree.write(filename)
 
 
     def write_model_map(self, fileName, poisson=False):
@@ -941,7 +940,7 @@ class HAL(PluginPrototype):
         This function writes the model map to a file. (it is currently not implemented)
         The interface is based off of HAWCLike for consistency
         """
-        self._write_a_map(fileName, 'model', poisson):
+        self._write_a_map(fileName, 'model', poisson)
         
 
 
@@ -950,4 +949,4 @@ class HAL(PluginPrototype):
         This function writes the residual map to a file. (it is currently not implemented)
         The interface is based off of HAWCLike for consistency
         """
-        self._write_a_map(fileName, 'residual', False):
+        self._write_a_map(fileName, 'residual', False)

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -907,7 +907,7 @@ class HAL(PluginPrototype):
             '''
             THIS IS ONLY A TEST
             '''
-            fake_data=data_analysis_bin.observation_map #model_map+bkg
+            fake_data=model_map+bkg
 
             this_bin = DataAnalysisBin(plane_id,
                                    observation_hpx_map=fake_data,

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -683,7 +683,7 @@ class HAL(PluginPrototype):
         n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
         # This is the resolution (i.e., the size of one pixel) of the image
-        resolution = 3.0 # arcmin
+        resolution = 3.0  # arcmin
 
         # The image is going to cover the diameter plus 20% padding
         xsize = self._get_optimal_xsize(resolution)
@@ -706,7 +706,7 @@ class HAL(PluginPrototype):
                 this_ra, this_dec = self._roi.ra_dec_center
 
                 # Make a full healpix map for a second
-                whole_map=self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
+                whole_map = self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
 
                 # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
                 longitude = ra_to_longitude(this_ra)
@@ -715,7 +715,7 @@ class HAL(PluginPrototype):
                 latitude = this_dec
 
                 # Background and excess maps
-                bkg_subtracted, data_map, background_map = self._get_excess(data_analysis_bin,all=True)
+                bkg_subtracted, data_map, background_map = self._get_excess(data_analysis_bin, all=True)
 
                 # Make all the projections: model, excess, background, residuals
                 proj_model = self._represent_healpix_map(fig, whole_map,
@@ -852,9 +852,6 @@ class HAL(PluginPrototype):
 
         return n_points
 
-
-
-
     def _get_model_map(self, plane_id, n_pt_src, n_ext_src):
         """
         This function returns a model map for a particular bin
@@ -869,30 +866,27 @@ class HAL(PluginPrototype):
                                   self._active_pixels[plane_id],
                                   self._maptree[plane_id].observation_map.nside)
 
-
         return model_map
 
-
-    def _get_excess(self, data_analysis_bin, all=True ):
+    def _get_excess(self, data_analysis_bin, all=True):
         """
         This function returns the excess counts for a particular bin
         if all=True, also returns the data and background maps
         """
         data_map = data_analysis_bin.observation_map.as_dense()
-        bkg_map  = data_analysis_bin.background_map.as_dense()
+        bkg_map = data_analysis_bin.background_map.as_dense()
         excess = data_map - bkg_map
 
         if all:
-            return excess, data_map, bkg_map 
+            return excess, data_map, bkg_map
         return excess
-
 
     def _write_a_map(self, filename, which, poisson=False):
         """
         This writes either a model map or a residual map, depending on which one is preferred
         """
         which = which.lower()
-        assert which in [ 'model', 'residual' ]
+        assert which in ['model', 'residual']
 
         n_pt = self._likelihood_model.get_number_of_point_sources()
         n_ext = self._likelihood_model.get_number_of_extended_sources()
@@ -901,38 +895,37 @@ class HAL(PluginPrototype):
 
         if poisson:
             poisson_set = self.get_simulated_dataset("model map")
-  
+
         for plane_id in self._active_planes:
 
-            data_analysis_bin=self._maptree[plane_id]
+            data_analysis_bin = self._maptree[plane_id]
 
-            bkg=data_analysis_bin.background_map
-            obs=data_analysis_bin.observation_map
+            bkg = data_analysis_bin.background_map
+            obs = data_analysis_bin.observation_map
 
             if poisson:
                 model_excess = poisson_set._maptree[plane_id].observation_map - poisson_set._maptree[plane_id].background_map
             else:
                 model_excess = self._get_model_map(plane_id, n_pt, n_ext)
-            
-            if which=='residual':
+
+            if which == 'residual':
                 bkg += model_excess
 
-            if which=='model':
+            if which == 'model':
                 obs = model_excess + bkg
 
             this_bin = DataAnalysisBin(plane_id,
-                                   observation_hpx_map=obs,
-                                   background_hpx_map=bkg,
-                                   active_pixels_ids=self._active_pixels[plane_id],
-                                   n_transits=data_analysis_bin.n_transits,
-                                   scheme='RING')
+                                       observation_hpx_map=obs,
+                                       background_hpx_map=bkg,
+                                       active_pixels_ids=self._active_pixels[plane_id],
+                                       n_transits=data_analysis_bin.n_transits,
+                                       scheme='RING')
 
-            map_analysis_bins[plane_id]=this_bin
+            map_analysis_bins[plane_id] = this_bin
 
-        #save the file
+        # save the file
         new_map_tree = MapTree(map_analysis_bins, self._roi)
         new_map_tree.write(filename)
-
 
     def write_model_map(self, fileName, poisson=False):
         """
@@ -940,8 +933,6 @@ class HAL(PluginPrototype):
         The interface is based off of HAWCLike for consistency
         """
         self._write_a_map(fileName, 'model', poisson)
-        
-
 
     def write_residual_map(self, fileName):
         """

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -820,7 +820,8 @@ class HAL(PluginPrototype):
 
         proj = self._represent_healpix_map(fig, total, longitude, latitude, xsize, resolution, smoothing_kernel_sigma)
 
-        sub.imshow(proj, origin='lower')
+        cax = sub.imshow(proj, origin='lower')
+        fig.colorbar(cax)
         sub.axis('off')
 
         hp.graticule(delta_coord, delta_coord)
@@ -869,7 +870,7 @@ class HAL(PluginPrototype):
     def _get_excess(self, data_analysis_bin, all_maps=True):
         """
         This function returns the excess counts for a particular bin
-        if all=True, also returns the data and background maps
+        if all_maps=True, also returns the data and background maps
         """
         data_map = data_analysis_bin.observation_map.as_dense()
         bkg_map = data_analysis_bin.background_map.as_dense()
@@ -879,7 +880,7 @@ class HAL(PluginPrototype):
             return excess, data_map, bkg_map
         return excess
 
-    def _write_a_map(self, file_name, which, fluctuate=False):
+    def _write_a_map(self, file_name, which, fluctuate=False, return_map=False):
         """
         This writes either a model map or a residual map, depending on which one is preferred
         """
@@ -926,16 +927,27 @@ class HAL(PluginPrototype):
         new_map_tree = MapTree(map_analysis_bins, self._roi)
         new_map_tree.write(file_name)
 
-    def write_model_map(self, file_name, poisson_fluctuate=False):
+        if return_map:
+            return new_map_tree
+
+    def write_model_map(self, file_name, poisson_fluctuate=False, test_return_map=False):
         """
         This function writes the model map to a file. (it is currently not implemented)
         The interface is based off of HAWCLike for consistency
         """
-        self._write_a_map(file_name, 'model', poisson_fluctuate)
+        if test_return_map:
+            print("You should only return a model map here for testing purposes!")
+            return self._write_a_map(file_name, 'model', poisson_fluctuate, test_return_map)
+        else:
+            self._write_a_map(file_name, 'model', poisson_fluctuate, test_return_map)
 
-    def write_residual_map(self, file_name):
+    def write_residual_map(self, file_name, test_return_map=False):
         """
         This function writes the residual map to a file. (it is currently not implemented)
         The interface is based off of HAWCLike for consistency
         """
-        self._write_a_map(file_name, 'residual')
+        if test_return_map:
+            print("You should only return a residual map here for testing purposes!")
+            return self._write_a_map(file_name, 'residual', False, test_return_map)
+        else:
+            self._write_a_map(file_name, 'residual', False, test_return_map)

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -899,36 +899,35 @@ class HAL(PluginPrototype):
 
         map_analysis_bins = collections.OrderedDict()
 
+        if poisson:
+            poisson_set = self.get_simulated_dataset("model map")
+  
         for plane_id in self._active_planes:
 
             data_analysis_bin=self._maptree[plane_id]
 
             bkg=data_analysis_bin.background_map
+            obs=data_analysis_bin.observation_map
+
+            if poisson:
+                model_excess = poisson_set._maptree[plane_id].observation_map - poisson_set._maptree[plane_id].background_map
+            else:
+                model_excess = self._get_model_map(plane_id, n_pt, n_ext)
+            
+            if which=='residual':
+                bkg += model_excess
 
             if which=='model':
-                bin_map=self._get_model_map(plane_id, n_pt, n_ext)
-                fake_data=bin_map+bkg
-            else:
-                bin_map=data_analysis_bin.observation_map
-                fake_data=bin_map-bkg
-
+                obs = model_excess + bkg
 
             this_bin = DataAnalysisBin(plane_id,
-                                   observation_hpx_map=fake_data,
+                                   observation_hpx_map=obs,
                                    background_hpx_map=bkg,
                                    active_pixels_ids=self._active_pixels[plane_id],
                                    n_transits=data_analysis_bin.n_transits,
                                    scheme='RING')
 
             map_analysis_bins[plane_id]=this_bin
-
-            
-
-            
-            if poisson:
-                #do stuff later
-                pass
-
 
         #save the file
         new_map_tree = MapTree(map_analysis_bins, self._roi)

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -854,3 +854,28 @@ class HAL(PluginPrototype):
             n_points += self._maptree[bin_id].observation_map.as_partial().shape[0]
 
         return n_points
+
+
+    def write_model_map(self, fileName, poisson=False):
+        """
+        This function writes the model map to a file. (it is currently not implemented)
+        The interface is based off of HAWCLike for consistency
+        """
+        #make model map
+        #poisson fluctuate if necassary
+        #save the map
+        #return nothing
+        print("This function doesn't do anything yet")
+        pass
+
+
+    def write_residual_map(self, fileName):
+        """
+        This function writes the residual map to a file. (it is currently not implemented)
+        The interface is based off of HAWCLike for consistency
+        """
+        #make model map
+        #subtract data map
+        #save the map
+        #return nothing
+        pass

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -702,12 +702,8 @@ class HAL(PluginPrototype):
                 # Get the center of the projection for this plane
                 this_ra, this_dec = self._roi.ra_dec_center
 
-                this_model_map_hpx = self._get_expectation(data_analysis_bin, plane_id, n_point_sources, n_ext_sources)
-
                 # Make a full healpix map for a second
-                whole_map = SparseHealpix(this_model_map_hpx,
-                                          self._active_pixels[plane_id],
-                                          data_analysis_bin.observation_map.nside).as_dense()
+                whole_map=self._get_model_map(plane_id, n_point_sources, n_ext_sources,fullSky=True)
 
                 # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
                 longitude = ra_to_longitude(this_ra)
@@ -856,11 +852,34 @@ class HAL(PluginPrototype):
         return n_points
 
 
-    def write_model_map(self, fileName, poisson=False):
+
+
+    def _get_model_map(self, plane_id, n_pt_src, n_ext_src, fullSky=True ):
+        """
+        This function returns a model map for a particular bin
+        """
+
+        if not (plane_id in self._active_planes):
+            raise ValueError("{0} not a plane in the current model".format(plane_id))
+
+        this_model_map_hpx = self._get_expectation(self._maptree[plane_id], plane_id, n_pt_src, n_ext_src)
+
+        model_map = SparseHealpix(this_model_map_hpx,
+                                  self._active_pixels[plane_id],
+                                  self._maptree[plane_id].observation_map.nside)
+        # Make a full healpix map for a second
+        if fullSky:
+            model_map=model_map.as_dense()
+
+        return model_map
+
+    def write_model_map(self, fileName="testingONLY", poisson=False, partial=False):
         """
         This function writes the model map to a file. (it is currently not implemented)
         The interface is based off of HAWCLike for consistency
         """
+    
+
         #make model map
         #poisson fluctuate if necassary
         #save the map
@@ -878,4 +897,5 @@ class HAL(PluginPrototype):
         #subtract data map
         #save the map
         #return nothing
+        print("This function doesn't do anything yet")
         pass

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -19,8 +19,8 @@ from threeML.io.progress_bar import progress_bar
 from astromodels import Parameter
 
 from hawc_hal.maptree import map_tree_factory
-from hawc_hal.maptree import MapTree
-from hawc_hal.maptree import DataAnalysisBin
+from hawc_hal.maptree.map_tree import MapTree
+from hawc_hal.maptree.data_analysis_bin import DataAnalysisBin
 from hawc_hal.response import hawc_response_factory
 from hawc_hal.convolved_source import ConvolvedPointSource, \
     ConvolvedExtendedSource3D, ConvolvedExtendedSource2D, ConvolvedSourcesContainer

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -711,7 +711,6 @@ class HAL(PluginPrototype):
                 # Declination is already between -90 and 90
                 latitude = this_dec
 
-
                 # Background and excess maps
 
                 # Make all the projections: model, excess, background, residuals
@@ -862,12 +861,12 @@ class HAL(PluginPrototype):
         if not (plane_id in self._active_planes):
             raise ValueError("{0} not a plane in the current model".format(plane_id))
 
-        this_model_map_hpx = self._get_expectation(self._maptree[plane_id], plane_id, n_pt_src, n_ext_src)
+        expect = self._get_expectation(self._maptree[plane_id], plane_id, n_pt_src, n_ext_src)
 
-        model_map = SparseHealpix(this_model_map_hpx,
+        model_map = SparseHealpix(expect,
                                   self._active_pixels[plane_id],
                                   self._maptree[plane_id].observation_map.nside)
-        # Make a full healpix map for a second
+
         if fullSky:
             model_map=model_map.as_dense()
 

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -76,33 +76,33 @@ class SparseHealpix(HealpixWrapperBase):
 
     def __add__(self, other_map):
         
-        #Make sure they have the same pixels
+        # Make sure they have the same pixels
         assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
 
-        #inflate them
-        big_self_map=self.as_dense()
+        # inflate them
+        big_self_map = self.as_dense()
         
-        big_other_map=other_map.as_dense()
+        big_other_map = other_map.as_dense()
         
-        #add them
-        dense_added=big_self_map+big_other_map
+        # add them
+        dense_added = big_self_map + big_other_map
 
-        #deflate
-        sparse_added=SparseHealpix(dense_added[self._pixels_ids],self._pixels_ids,self.nside)
+        # deflate
+        sparse_added = SparseHealpix(dense_added[self._pixels_ids], self._pixels_ids, self.nside)
         
         return sparse_added
 
     def __sub__(self, other_map):
 
-        #Make sure they have the same pixels
+        # Make sure they have the same pixels
         assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
         
-        big_other_map=other_map.as_dense()
-        big_self_map=self.as_dense()
+        big_other_map = other_map.as_dense()
+        big_self_map = self.as_dense()
         
-        subtraction= big_self_map - big_other_map
+        subtraction = big_self_map - big_other_map
 
-        sparse_subtracted=SparseHealpix(subtraction[self._pixels_ids],self._pixels_ids,self.nside)
+        sparse_subtracted = SparseHealpix(subtraction[self._pixels_ids], self._pixels_ids, self.nside)
         
         return sparse_subtracted
 

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -74,6 +74,24 @@ class SparseHealpix(HealpixWrapperBase):
 
         super(SparseHealpix, self).__init__(sparse=True, nside=nside)
 
+    def __add__(self, other_map):
+        
+        #Make sure they have the same pixels
+        assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
+
+        #inflate them
+        big_self_map=self.as_dense()
+        
+        big_other_map=other_map.as_dense()
+        
+        #add them
+        dense_added=big_self_map+big_other_map
+
+        #deflate
+        sparse_added=SparseHealpix(dense_added[self._pixels_ids],self._pixels_ids,self.nside)
+        
+        return sparse_added
+        
     def as_dense(self):
         """
         Returns the dense (i.e., full sky) representation of the map. Note that this means unwrapping the map,

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -78,9 +78,9 @@ class SparseHealpix(HealpixWrapperBase):
         # Make sure they have the same pixels
         assert np.array_equal(self._pixels_ids, other_map.pixels_ids)
 
-        dense_added = self.as_partial() + other_map.as_partial()
+        added = self.as_partial() + other_map.as_partial()
 
-        sparse_added = SparseHealpix(dense_added, self._pixels_ids, self.nside)
+        sparse_added = SparseHealpix(added, self._pixels_ids, self.nside)
         
         return sparse_added
 

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -76,32 +76,22 @@ class SparseHealpix(HealpixWrapperBase):
     def __add__(self, other_map):
 
         # Make sure they have the same pixels
-        assert np.array_equal(self.pixels, other_map.pixels)
+        assert np.array_equal(self._pixels_ids, other_map.pixels_ids)
 
-        # inflate them
-        big_self_map = self.as_dense()
-        
-        big_other_map = other_map.as_dense()
-        
-        # add them
-        dense_added = big_self_map + big_other_map
+        dense_added = self.as_partial() + other_map.as_partial()
 
-        # deflate
-        sparse_added = SparseHealpix(dense_added[self.pixels], self.pixels, self.nside)
+        sparse_added = SparseHealpix(dense_added, self._pixels_ids, self.nside)
         
         return sparse_added
 
     def __sub__(self, other_map):
 
         # Make sure they have the same pixels
-        assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
+        assert np.array_equal(self._pixels_ids, other_map.pixels_ids)
 
-        big_other_map = other_map.as_dense()
-        big_self_map = self.as_dense()
+        subtraction = self.as_partial() - other_map.as_partial()
 
-        subtraction = big_self_map - big_other_map
-
-        sparse_subtracted = SparseHealpix(subtraction[self.pixels], self.pixels, self.nside)
+        sparse_subtracted = SparseHealpix(subtraction, self._pixels_ids, self.nside)
 
         return sparse_subtracted
 
@@ -117,7 +107,7 @@ class SparseHealpix(HealpixWrapperBase):
         new_map = np.full(self.npix, self._fill_value)
 
         # Assign the active pixels their values
-        new_map[self.pixels] = self._partial_map
+        new_map[self._pixels_ids] = self._partial_map
 
         return new_map
 
@@ -132,7 +122,7 @@ class SparseHealpix(HealpixWrapperBase):
         self._partial_map[:] = new_values
 
     @property
-    def pixels(self):
+    def pixels_ids(self):
         return self._pixels_ids
 
 

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -91,7 +91,21 @@ class SparseHealpix(HealpixWrapperBase):
         sparse_added=SparseHealpix(dense_added[self._pixels_ids],self._pixels_ids,self.nside)
         
         return sparse_added
+
+    def __sub__(self, other_map):
+
+        #Make sure they have the same pixels
+        assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
         
+        big_other_map=other_map.as_dense()
+        big_self_map=self.as_dense()
+        
+        subtraction= big_self_map - big_other_map
+
+        sparse_subtracted=SparseHealpix(subtraction[self._pixels_ids],self._pixels_ids,self.nside)
+        
+        return sparse_subtracted
+
     def as_dense(self):
         """
         Returns the dense (i.e., full sky) representation of the map. Note that this means unwrapping the map,

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -20,7 +20,6 @@ class HealpixWrapperBase(object):
         self._nside = int(nside)
         self._npix = hp.nside2npix(self._nside)
         self._pixel_area = hp.nside2pixarea(self._nside, degrees=True)
-
         self._sparse = bool(sparse)
 
     @property
@@ -75,9 +74,9 @@ class SparseHealpix(HealpixWrapperBase):
         super(SparseHealpix, self).__init__(sparse=True, nside=nside)
 
     def __add__(self, other_map):
-        
+
         # Make sure they have the same pixels
-        assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
+        assert np.array_equal(self.pixels, other_map.pixels)
 
         # inflate them
         big_self_map = self.as_dense()
@@ -88,7 +87,7 @@ class SparseHealpix(HealpixWrapperBase):
         dense_added = big_self_map + big_other_map
 
         # deflate
-        sparse_added = SparseHealpix(dense_added[self._pixels_ids], self._pixels_ids, self.nside)
+        sparse_added = SparseHealpix(dense_added[self.pixels], self.pixels, self.nside)
         
         return sparse_added
 
@@ -96,14 +95,14 @@ class SparseHealpix(HealpixWrapperBase):
 
         # Make sure they have the same pixels
         assert np.array_equal(self._pixels_ids, other_map._pixels_ids)
-        
+
         big_other_map = other_map.as_dense()
         big_self_map = self.as_dense()
-        
+
         subtraction = big_self_map - big_other_map
 
-        sparse_subtracted = SparseHealpix(subtraction[self._pixels_ids], self._pixels_ids, self.nside)
-        
+        sparse_subtracted = SparseHealpix(subtraction[self.pixels], self.pixels, self.nside)
+
         return sparse_subtracted
 
     def as_dense(self):
@@ -118,7 +117,7 @@ class SparseHealpix(HealpixWrapperBase):
         new_map = np.full(self.npix, self._fill_value)
 
         # Assign the active pixels their values
-        new_map[self._pixels_ids] = self._partial_map
+        new_map[self.pixels] = self._partial_map
 
         return new_map
 
@@ -131,6 +130,10 @@ class SparseHealpix(HealpixWrapperBase):
         assert new_values.shape == self._partial_map.shape
 
         self._partial_map[:] = new_values
+
+    @property
+    def pixels(self):
+        return self._pixels_ids
 
 
 

--- a/hawc_hal/maptree/__init__.py
+++ b/hawc_hal/maptree/__init__.py
@@ -1,3 +1,1 @@
 from map_tree import map_tree_factory
-from map_tree import MapTree
-from data_analysis_bin import DataAnalysisBin

--- a/hawc_hal/maptree/__init__.py
+++ b/hawc_hal/maptree/__init__.py
@@ -1,1 +1,3 @@
 from map_tree import map_tree_factory
+from map_tree import MapTree
+from data_analysis_bin import DataAnalysisBin

--- a/hawc_hal/maptree/data_analysis_bin.py
+++ b/hawc_hal/maptree/data_analysis_bin.py
@@ -6,7 +6,6 @@ class DataAnalysisBin(object):
     def __init__(self, name, observation_hpx_map, background_hpx_map, active_pixels_ids, n_transits, scheme='RING'):
 
         # Get nside
-
         self._nside = observation_hpx_map.nside
 
         nside_bkg = background_hpx_map.nside

--- a/scripts/hal_hdf5_to_fits.py
+++ b/scripts/hal_hdf5_to_fits.py
@@ -1,11 +1,15 @@
 from hawc_hal.maptree import map_tree_factory
+from astropy.io import fits
+
+from IPython import embed
 
 import healpy as hp
 import numpy as np
+
 import argparse
 import os
+from datetime import datetime
 
-cwd=os.getcwd()
 
 parser = argparse.ArgumentParser(description='Process some integers.')
 
@@ -17,11 +21,16 @@ parser.add_argument('--output', metavar='output', type=str,
                     default="map",
                     help='pick a file prefix (e.g. given "test" -> test_binX.fits.gz)')
 
+parser.add_argument('--overwrite',
+                    action="store_true",
+                    help='Overwrite existing files')
+
 
 args = parser.parse_args()
 
 filename=os.path.expandvars(args.input)
 outfile=os.path.expandvars(args.output)
+clobber=args.overwrite
 
 if not os.path.isfile(filename):
     print("You must enter a valid file!")
@@ -32,24 +41,103 @@ if not os.path.isfile(filename):
 # this throws a warning for partial map trees but its OK
 maptree = map_tree_factory(filename, None)
 
+
+now=datetime.now()
+startMJD=56987.9286332
+
+
+#FIRST HEADER
+'''
+COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy
+COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H 
+DATE    = '2018-12-01T02:31:14' / file creation date (YYYY-MM-DDThh:mm:ss UT)   
+STARTMJD=     56987.9286332451 / MJD of first event                             
+STOPMJD =     58107.2396848326 / MJD of last event                              
+NEVENTS =                  -1. / Number of events in map                        
+TOTDUR  =     24412.9020670185 / Total integration time [hours]                 
+DURATION=      1.9943578604616 / Avg integration time [hours]                   
+MAPTYPE = 'duration'           / e.g. Skymap, Moonmap                           
+MAXDUR  =                  -1. / Max integration time [hours]                   
+MINDUR  =                  -1. / Min integration time [hours]                   
+EPOCH   = 'unknown '           / e.g. J2000, current, J2016, B1950, etc.        
+HIERARCH MAPFILETYPE = 'duration' / e.g. standard, duration, integration   
+'''
+
+
+FITS_COMMENT="FITS (Flexible Image Transport System) format is defined in 'Astronomy and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H"
+
+primary_keys=['COMMENT', 'COMMENT', 'DATE', 'STARTMJD', 'STOPMJD',
+              'NEVENTS', 'TOTDUR', 'DURATION', 'MAPTYPE', 'MAXDUR', 
+              'MINDUR', 'EPOCH', 'MAPFILETYPE']
+
+primary_values=[FITS_COMMENT  ,   FITS_COMMENT, "{0}".format(now), 56987.9286332451, 58107.2396848326,
+              -1.0, 24412.9020670185, 1.9943578604616, 'duration', -1.0, -1.0, 'unknown', 'duration']
+
+primary_comments=["file does conform to FITS standard",
+                  "number of bits per data pixel",
+                  "number of data axes",
+                  "FITS dataset may contain extension",
+                  "MJD of first event", "MJD of last event",
+                  "Number of events in map",
+                  "Total integration time [hours]",
+                  "Avg integration time [hours]",
+                  "e.g. Skymap, Moonmap",
+                  "Max integration time [hours]",
+                  "Min integration time [hours]",
+                  "e.g. J2000, current, J2016, B1950, etc.",
+                  "e.g. standard, duration, integration"]
+
+
+
+labels=['data map', 'background map', 'exposure map']
+label_format=[ np.float64 for i in range(len(labels)) ]
+label_units=[ 'unknown' for i in range(len(labels)) ]
+
+
 for i, analysis_bin in enumerate(maptree.analysis_bins_labels):
-    #properties
     map_bin    = maptree[analysis_bin]
+    #properties
     nside      = map_bin.nside
     npix       = map_bin.npix
     see_pixels = map_bin.observation_map._pixels_ids
+    transits   = map_bin.n_transits
+    scheme     = map_bin.scheme
+
+    nest_scheme=False
+    if scheme.lower()=='nested':
+        nest_scheme=True
 
     #what we want
     data  = map_bin.observation_map.as_dense()
     bkg   = map_bin.background_map.as_dense()
-    zeros = np.zeros(npix)
 
+    zeros = np.empty(npix)
+    zeros.fill(9e9)
 
     outFileName="{0}_bin{1}.fits.gz".format(outfile,analysis_bin)
     #I probably need to add some header info, but yeah
-    hp.fitsfunc.write_map(outFileName, (data, bkg, zeros), partial=True, fits_IDL=False)
+    hp.fitsfunc.write_map(outFileName, (data, bkg, zeros), 
+                          column_names=labels, column_units=label_units, dtype=label_format, 
+                          partial=False, fits_IDL=True, overwrite=clobber, nest=nest_scheme)
 
+
+    #add the cards to the header
+    with fits.open(outFileName,'update') as hdu1:
+        hdr=hdu1[0].header
+
+        for i,key in enumerate(primary_keys):
+            val=primary_values[i]
+            comment=primary_comments[i]
+
+            if key=='TOTDUR':
+                val=24.0*transits
+        
+            if key=='STOPMJD':
+                val=startMJD+transits
+
+            entry=(val,comment)
+
+            hdr[key]=entry
+
+        #File is now closed
     print("File Written: {0}".format(outFileName))
-
-
-

--- a/scripts/hal_hdf5_to_fits.py
+++ b/scripts/hal_hdf5_to_fits.py
@@ -63,7 +63,6 @@ EPOCH   = 'unknown '           / e.g. J2000, current, J2016, B1950, etc.
 HIERARCH MAPFILETYPE = 'duration' / e.g. standard, duration, integration   
 '''
 
-
 FITS_COMMENT="FITS (Flexible Image Transport System) format is defined in 'Astronomy and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H"
 
 primary_keys=['COMMENT', 'COMMENT', 'DATE', 'STARTMJD', 'STOPMJD',

--- a/scripts/hal_hdf5_to_fits.py
+++ b/scripts/hal_hdf5_to_fits.py
@@ -1,0 +1,55 @@
+from hawc_hal.maptree import map_tree_factory
+
+import healpy as hp
+import numpy as np
+import argparse
+import os
+
+cwd=os.getcwd()
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+
+parser.add_argument('--input', metavar='input', type=str,
+                    required=True,
+                    help='pick an hdf5 file as input')
+
+parser.add_argument('--output', metavar='output', type=str, 
+                    default="map",
+                    help='pick a file prefix (e.g. given "test" -> test_binX.fits.gz)')
+
+
+args = parser.parse_args()
+
+filename=os.path.expandvars(args.input)
+outfile=os.path.expandvars(args.output)
+
+if not os.path.isfile(filename):
+    print("You must enter a valid file!")
+    exit(1)
+
+
+# Export the entire map tree (full sky)
+# this throws a warning for partial map trees but its OK
+maptree = map_tree_factory(filename, None)
+
+for i, analysis_bin in enumerate(maptree.analysis_bins_labels):
+    #properties
+    map_bin    = maptree[analysis_bin]
+    nside      = map_bin.nside
+    npix       = map_bin.npix
+    see_pixels = map_bin.observation_map._pixels_ids
+
+    #what we want
+    data  = map_bin.observation_map.as_dense()
+    bkg   = map_bin.background_map.as_dense()
+    zeros = np.zeros(npix)
+
+
+    outFileName="{0}_bin{1}.fits.gz".format(outfile,analysis_bin)
+    #I probably need to add some header info, but yeah
+    hp.fitsfunc.write_map(outFileName, (data, bkg, zeros), partial=True, fits_IDL=False)
+
+    print("File Written: {0}".format(outFileName))
+
+
+

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -2,11 +2,13 @@ from hawc_hal import HAL, HealpixConeROI
 import matplotlib.pyplot as plt
 from threeML import *
 import os
+from os import getcwd
+from os.path import isfile
 from hawc_hal.maptree import map_tree_factory
 
 
 
-cwd=os.getcwd()
+cwd=getcwd()
 
 output = "{0}/data".format(cwd)
 
@@ -25,8 +27,8 @@ roi = HealpixConeROI(data_radius=data_radius,
 maptree = "{0}/geminga_maptree.root".format(output)
 response = "{0}/detector_response.root".format(output)
 
-assert os.path.isfile(maptree)
-assert os.path.isfile(response)
+assert isfile(maptree) == True
+assert isfile(response) == True
 
 hawc = HAL("HAWC",
            maptree,

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -1,0 +1,134 @@
+from hawc_hal import HAL, HealpixConeROI
+import matplotlib.pyplot as plt
+from threeML import *
+import os
+from hawc_hal.maptree import map_tree_factory
+
+
+
+cwd=os.getcwd()
+
+output = "{0}/data".format(cwd)
+
+assert os.path.isdir(output)
+
+
+# Define the ROI
+ra_src, dec_src = 101.75, 16.0
+
+data_radius = 5.0
+model_radius = 7.0
+
+roi = HealpixConeROI(data_radius=data_radius,
+                     model_radius=model_radius,
+                     ra=ra_src,
+                     dec=dec_src)
+
+#maptree = "/Volumes/Disk/maps/nHit/liff/maptree_1024.root"
+maptree = "{0}/geminga_maptree.root".format(output)
+response = "{0}/detector_response.root".format(output)
+
+hawc = HAL("HAWC",
+           maptree,
+           response,
+           roi)
+
+# Use from bin 1 to bin 9
+hawc.set_active_measurements(1, 9)
+
+# Display information about the data loaded and the ROI
+hawc.display()
+
+'''
+Define model: Two sources, 1 point, 1 extended
+
+Same declination, but offset in RA
+
+Different spectral index, but both power laws
+
+'''
+pt_shift=3.0
+ext_shift = 1.0
+
+# First source
+spectrum1 = Powerlaw()
+source1 = PointSource("point", ra=ra_src + pt_shift, dec=dec_src, spectral_shape=spectrum1)
+
+spectrum1.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s)
+spectrum1.piv = 1 * u.TeV
+spectrum1.index = -2.3
+
+spectrum1.piv.fix = True
+spectrum1.K.fix = True
+spectrum1.index.fix = True
+
+# Second source
+shape = Gaussian_on_sphere(lon0=ra_src - ext_shift, lat0=dec_src, sigma=0.3)
+spectrum2 = Powerlaw()
+source2 = ExtendedSource("extended", spatial_shape=shape, spectral_shape=spectrum2)
+
+spectrum2.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s) 
+spectrum2.piv = 1 * u.TeV
+spectrum2.index = -2.0  
+
+shape.lon0.fix=True
+shape.lat0.fix=True
+shape.sigma.fix=True
+spectrum2.piv.fix = True
+spectrum2.K.fix = True
+spectrum2.index.fix = True
+
+# Define model with both sources
+model = Model(source1, source2)
+
+# Define the data we are using
+data = DataList(hawc)
+
+# Define the JointLikelihood object (glue the data to the model)
+jl = JointLikelihood(model, data, verbose=False)
+
+# This has the effect of loading the model cache 
+fig = hawc.display_spectrum()
+
+# the test file names
+model_file_name = "{0}/test_model.hdf5".format(output)
+residual_file_name = "{0}/test_residual.hdf5".format(output)
+
+# Write the map trees for testing
+model_map_tree = hawc.write_model_map(model_file_name, poisson_fluctuate=True, test_return_map=True)
+residual_map_tree = hawc.write_residual_map(residual_file_name, test_return_map=True)
+
+# Read the maps back in
+hawc_model = map_tree_factory(model_file_name,roi)
+hawc_residual = map_tree_factory(residual_file_name,roi)
+
+# Check to see if it worked!
+for model_bin_name, residual_bin_name in zip(hawc_model.analysis_bins_labels, hawc_residual.analysis_bins_labels):
+
+    assert model_bin_name == residual_bin_name
+
+    '''
+    Check the model maps!
+    '''
+    model_bin = hawc_model[model_bin_name]
+
+    check_model = model_map_tree[model_bin_name]
+
+    # good model file
+    assert all( model_bin.observation_map.as_partial() == check_model.observation_map.as_partial() )
+    assert all( model_bin.background_map.as_partial() == check_model.background_map.as_partial() )
+    #good pixel ids (defined as same for both bkg and obs, so we only test one
+    assert all( model_bin.observation_map.pixels_ids == check_model.observation_map.pixels_ids )
+
+    '''
+    Now check the residual maps
+    '''
+    residual_bin = hawc_residual[residual_bin_name]
+
+    check_residual = residual_map_tree[residual_bin_name]
+
+    # good residual file
+    assert all( residual_bin.observation_map.as_partial() == check_residual.observation_map.as_partial() )
+    assert all( residual_bin.background_map.as_partial() == check_residual.background_map.as_partial() )
+    #good pixel ids (defined as same for both bkg and obs, so we only test one
+    assert all( residual_bin.observation_map.pixels_ids == check_residual.observation_map.pixels_ids )

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -10,8 +10,6 @@ cwd=os.getcwd()
 
 output = "{0}/data".format(cwd)
 
-assert os.path.isdir(output)
-
 
 # Define the ROI
 ra_src, dec_src = 101.75, 16.0
@@ -24,9 +22,11 @@ roi = HealpixConeROI(data_radius=data_radius,
                      ra=ra_src,
                      dec=dec_src)
 
-#maptree = "/Volumes/Disk/maps/nHit/liff/maptree_1024.root"
 maptree = "{0}/geminga_maptree.root".format(output)
 response = "{0}/detector_response.root".format(output)
+
+assert os.path.isfile(maptree)
+assert os.path.isfile(response)
 
 hawc = HAL("HAWC",
            maptree,

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -1,136 +1,141 @@
-from hawc_hal import HAL, HealpixConeROI
-import matplotlib.pyplot as plt
-from threeML import *
-#import os
-from os.path import isfile, dirname, realpath
-from hawc_hal.maptree import map_tree_factory
+import pytest
+
+@pytest.fixture
+def input():
+    from os.path import isfile, dirname, abspath
+    from hawc_hal import HealpixConeROI
+    # Define the ROI
+    ra_src, dec_src = 101.75, 16.0
+    
+    data_radius = 5.0
+    model_radius = 7.0
+    
+    roi = HealpixConeROI(data_radius=data_radius,
+                         model_radius=model_radius,
+                         ra=ra_src,
+                         dec=dec_src)
+
+    test_file = abspath(__file__)
+    file_dir = dirname(test_file)
+    output = "{0}/data".format(file_dir)
+
+    maptree = "{0}/geminga_maptree.root".format(output)
+    response = "{0}/detector_response.root".format(output)
+
+    assert isfile(maptree) == True
+    assert isfile(response) == True
+
+    return ( maptree, response, roi, output, ra_src, dec_src )
+
+def test_model_residual_maps(input):
+    from hawc_hal.maptree import map_tree_factory
+    from hawc_hal import HAL
+    from threeML import Model, JointLikelihood, DataList
+    import astropy.units as u
+    from astromodels import PointSource, ExtendedSource, Powerlaw, Gaussian_on_sphere
 
 
+    maptree, response, roi, output, ra_src, dec_src, = input
 
-test_file = realpath(__file__)
+    hawc = HAL("HAWC", maptree, response, roi)
 
-file_dir = dirname(test_file)
+    # Use from bin 1 to bin 9
+    hawc.set_active_measurements(1, 9)
 
-output = "{0}/data".format(file_dir)
-
-# Define the ROI
-ra_src, dec_src = 101.75, 16.0
-
-data_radius = 5.0
-model_radius = 7.0
-
-roi = HealpixConeROI(data_radius=data_radius,
-                     model_radius=model_radius,
-                     ra=ra_src,
-                     dec=dec_src)
-
-maptree = "{0}/geminga_maptree.root".format(output)
-response = "{0}/detector_response.root".format(output)
-
-assert isfile(maptree) == True
-assert isfile(response) == True
-
-hawc = HAL("HAWC",
-           maptree,
-           response,
-           roi)
-
-# Use from bin 1 to bin 9
-hawc.set_active_measurements(1, 9)
-
-# Display information about the data loaded and the ROI
-hawc.display()
-
-'''
-Define model: Two sources, 1 point, 1 extended
-
-Same declination, but offset in RA
-
-Different spectral index, but both power laws
-
-'''
-pt_shift=3.0
-ext_shift = 1.0
-
-# First source
-spectrum1 = Powerlaw()
-source1 = PointSource("point", ra=ra_src + pt_shift, dec=dec_src, spectral_shape=spectrum1)
-
-spectrum1.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s)
-spectrum1.piv = 1 * u.TeV
-spectrum1.index = -2.3
-
-spectrum1.piv.fix = True
-spectrum1.K.fix = True
-spectrum1.index.fix = True
-
-# Second source
-shape = Gaussian_on_sphere(lon0=ra_src - ext_shift, lat0=dec_src, sigma=0.3)
-spectrum2 = Powerlaw()
-source2 = ExtendedSource("extended", spatial_shape=shape, spectral_shape=spectrum2)
-
-spectrum2.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s) 
-spectrum2.piv = 1 * u.TeV
-spectrum2.index = -2.0  
-
-shape.lon0.fix=True
-shape.lat0.fix=True
-shape.sigma.fix=True
-spectrum2.piv.fix = True
-spectrum2.K.fix = True
-spectrum2.index.fix = True
-
-# Define model with both sources
-model = Model(source1, source2)
-
-# Define the data we are using
-data = DataList(hawc)
-
-# Define the JointLikelihood object (glue the data to the model)
-jl = JointLikelihood(model, data, verbose=False)
-
-# This has the effect of loading the model cache 
-fig = hawc.display_spectrum()
-
-# the test file names
-model_file_name = "{0}/test_model.hdf5".format(output)
-residual_file_name = "{0}/test_residual.hdf5".format(output)
-
-# Write the map trees for testing
-model_map_tree = hawc.write_model_map(model_file_name, poisson_fluctuate=True, test_return_map=True)
-residual_map_tree = hawc.write_residual_map(residual_file_name, test_return_map=True)
-
-# Read the maps back in
-hawc_model = map_tree_factory(model_file_name,roi)
-hawc_residual = map_tree_factory(residual_file_name,roi)
-
-# Check to see if it worked!
-for model_bin_name, residual_bin_name in zip(hawc_model.analysis_bins_labels, hawc_residual.analysis_bins_labels):
-
-    assert model_bin_name == residual_bin_name
+    # Display information about the data loaded and the ROI
+    hawc.display()
 
     '''
-    Check the model maps!
-    '''
-    model_bin = hawc_model[model_bin_name]
+    Define model: Two sources, 1 point, 1 extended
 
-    check_model = model_map_tree[model_bin_name]
+    Same declination, but offset in RA
 
-    # good model file
-    assert all( model_bin.observation_map.as_partial() == check_model.observation_map.as_partial() )
-    assert all( model_bin.background_map.as_partial() == check_model.background_map.as_partial() )
-    #good pixel ids (defined as same for both bkg and obs, so we only test one
-    assert all( model_bin.observation_map.pixels_ids == check_model.observation_map.pixels_ids )
+    Different spectral index, but both power laws
 
     '''
-    Now check the residual maps
-    '''
-    residual_bin = hawc_residual[residual_bin_name]
+    pt_shift=3.0
+    ext_shift = 1.0
 
-    check_residual = residual_map_tree[residual_bin_name]
+    # First source
+    spectrum1 = Powerlaw()
+    source1 = PointSource("point", ra=ra_src + pt_shift, dec=dec_src, spectral_shape=spectrum1)
 
-    # good residual file
-    assert all( residual_bin.observation_map.as_partial() == check_residual.observation_map.as_partial() )
-    assert all( residual_bin.background_map.as_partial() == check_residual.background_map.as_partial() )
-    #good pixel ids (defined as same for both bkg and obs, so we only test one
-    assert all( residual_bin.observation_map.pixels_ids == check_residual.observation_map.pixels_ids )
+    spectrum1.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s)
+    spectrum1.piv = 1 * u.TeV
+    spectrum1.index = -2.3
+
+    spectrum1.piv.fix = True
+    spectrum1.K.fix = True
+    spectrum1.index.fix = True
+
+    # Second source
+    shape = Gaussian_on_sphere(lon0=ra_src - ext_shift, lat0=dec_src, sigma=0.3)
+    spectrum2 = Powerlaw()
+    source2 = ExtendedSource("extended", spatial_shape=shape, spectral_shape=spectrum2)
+
+    spectrum2.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s) 
+    spectrum2.piv = 1 * u.TeV
+    spectrum2.index = -2.0  
+
+    shape.lon0.fix=True
+    shape.lat0.fix=True
+    shape.sigma.fix=True
+
+    spectrum2.piv.fix = True
+    spectrum2.K.fix = True
+    spectrum2.index.fix = True
+
+    # Define model with both sources
+    model = Model(source1, source2)
+
+    # Define the data we are using
+    data = DataList(hawc)
+
+    # Define the JointLikelihood object (glue the data to the model)
+    jl = JointLikelihood(model, data, verbose=False)
+
+    # This has the effect of loading the model cache 
+    fig = hawc.display_spectrum()
+
+    # the test file names
+    model_file_name = "{0}/test_model.hdf5".format(output)
+    residual_file_name = "{0}/test_residual.hdf5".format(output)
+
+    # Write the map trees for testing
+    model_map_tree = hawc.write_model_map(model_file_name, poisson_fluctuate=True, test_return_map=True)
+    residual_map_tree = hawc.write_residual_map(residual_file_name, test_return_map=True)
+
+    # Read the maps back in
+    hawc_model = map_tree_factory(model_file_name,roi)
+    hawc_residual = map_tree_factory(residual_file_name,roi)
+
+    # Check to see if it worked!
+    for model_bin_name, residual_bin_name in zip(hawc_model.analysis_bins_labels, hawc_residual.analysis_bins_labels):
+
+        assert model_bin_name == residual_bin_name
+
+        '''
+        Check the model maps!
+        '''
+        model_bin = hawc_model[model_bin_name]
+
+        check_model = model_map_tree[model_bin_name]
+
+        # good model file
+        assert all( model_bin.observation_map.as_partial() == check_model.observation_map.as_partial() )
+        assert all( model_bin.background_map.as_partial() == check_model.background_map.as_partial() )
+        # good pixel ids (defined as same for both bkg and obs, so we only test one
+        assert all( model_bin.observation_map.pixels_ids == check_model.observation_map.pixels_ids )
+
+        '''
+        Now check the residual maps
+        '''
+        residual_bin = hawc_residual[residual_bin_name]
+
+        check_residual = residual_map_tree[residual_bin_name]
+
+        # good residual file
+        assert all( residual_bin.observation_map.as_partial() == check_residual.observation_map.as_partial() )
+        assert all( residual_bin.background_map.as_partial() == check_residual.background_map.as_partial() )
+        # good pixel ids (defined as same for both bkg and obs, so we only test one
+        assert all( residual_bin.observation_map.pixels_ids == check_residual.observation_map.pixels_ids )

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -1,17 +1,17 @@
 from hawc_hal import HAL, HealpixConeROI
 import matplotlib.pyplot as plt
 from threeML import *
-import os
-from os import getcwd
-from os.path import isfile
+#import os
+from os.path import isfile, dirname, realpath
 from hawc_hal.maptree import map_tree_factory
 
 
 
-cwd=getcwd()
+test_file = realpath(__file__)
 
-output = "{0}/data".format(cwd)
+file_dir = dirname(test_file)
 
+output = "{0}/data".format(file_dir)
 
 # Define the ROI
 ra_src, dec_src = 101.75, 16.0


### PR DESCRIPTION
This branch should now properly implement making model and residuals maps. 
I also have added a script to convert the hdf5 files to fits for compatibility with older hawc tools (this could probably use some better info from the origin maptrees, but it approximately works so far.