### PR TITLE
When computing saturated log likelihood, only include active analysis…

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -199,7 +199,7 @@ class HAL(PluginPrototype):
 
         :return:
         """
-        return sum(self._saturated_model_like_per_maptree.values())
+        return sum(self._saturated_model_like_per_maptree[bin_label] for bin_label in self._active_planes)
 
     def set_active_measurements(self, bin_id_min=None, bin_id_max=None, bin_list=None):
         """

--- a/hawc_hal/maptree/map_tree.py
+++ b/hawc_hal/maptree/map_tree.py
@@ -76,7 +76,7 @@ class MapTree(object):
         first_analysis_bin = maptree["bin_name 0"]
 
         :param item: string for access by name
-        :return: the analysis bin_name
+        :return: the analysis bin
         """
 
         try:
@@ -85,7 +85,7 @@ class MapTree(object):
 
         except IndexError:
 
-            raise IndexError("Analysis bin_name with index %i does not exist" % (item))
+            raise IndexError("Analysis bin with index %i does not exist" % (item))
 
     def __len__(self):
 


### PR DESCRIPTION
… bins.

Map trees normally contain data for analysis bins with very marginal statistics that are not normally used in analysis.  The user probably expects the saturated likelihood computed using only the bins active in the analysis rather than all of the bins.

(Also I changed what look like a couple of typos in a doc string and error message.)