### PR TITLE
fixed misleading error message

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -234,7 +234,7 @@ class HAL(PluginPrototype):
                 this_bin = str(this_bin)
                 if this_bin not in self._all_planes:
 
-                    raise ValueError("Bin {0} it not contained in this maptree".format(this_bin))
+                    raise ValueError("Bin {0} is not contained in this maptree".format(this_bin))
 
                 self._active_planes.append(this_bin)
 
@@ -250,7 +250,7 @@ class HAL(PluginPrototype):
 
                 if not this_bin in self._all_planes:
 
-                    raise ValueError("Bin {0} it not contained in this maptree".format(this_bin))
+                    raise ValueError("Bin {0} is not contained in this maptree".format(this_bin))
 
                 self._active_planes.append(this_bin)
 

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -169,7 +169,6 @@ class HAL(PluginPrototype):
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
-
             #Only set up PSF convolutors for active bins.
             if bin_id in self._active_planes:
                 self._psf_convolutors[bin_id] = PSFConvolutor(central_response_bins[bin_id].psf,
@@ -235,7 +234,7 @@ class HAL(PluginPrototype):
                 this_bin = str(this_bin)
                 if this_bin not in self._all_planes:
 
-                    raise ValueError("Bin %s it not contained in this response" % this_bin)
+                    raise ValueError("Bin {0} it not contained in this maptree".format(this_bin))
 
                 self._active_planes.append(this_bin)
 
@@ -251,7 +250,7 @@ class HAL(PluginPrototype):
 
                 if not this_bin in self._all_planes:
 
-                    raise ValueError("Bin %s it not contained in this response" % this_bin)
+                    raise ValueError("Bin {0} it not contained in this maptree".format(this_bin))
 
                 self._active_planes.append(this_bin)
 


### PR DESCRIPTION
This branch is to fix #26. `active_measurements` only looks at the maptree, so saying the missing bin is in the response file leads the user in the wrong direction for investigating a problem