### PR TITLE
No interpolation for instrument response containing a single dec bin

### DIFF
--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -72,6 +72,7 @@ class HAWCResponse(object):
         
         if len(dec_bins) < 2:
           custom_warnings.warn("Only {0} dec bins given in {1}, will not try to interpolate.".format(len(dec_bins), response_file_name))
+          custom_warnings.warn("Single-dec-bin mode is intended for development work only at this time and may not work with extended sources.")
 
     @classmethod
     def from_hdf5(cls, response_file_name):

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -62,6 +62,9 @@ class HAWCResponse(object):
         self._response_file_name = response_file_name
         self._dec_bins = dec_bins
         self._response_bins = response_bins
+        
+        if len(dec_bins) < 2:
+          custom_warnings.warn("Only {0} dec bins given in {1}, will not try to interpolate.".format(len(dec_bins), response_file_name))
 
     @classmethod
     def from_hdf5(cls, response_file_name):
@@ -259,6 +262,10 @@ class HAWCResponse(object):
         # Sort declination bins by distance to the provided declination
         dec_bins_keys = self._response_bins.keys()
         dec_bins_by_distance = sorted(dec_bins_keys, key=lambda x: abs(x - dec))
+        
+        #never try to interpolate if only one dec bin is given
+        if len(dec_bins_keys) < 2:
+          interpolate = False
 
         if not interpolate:
 


### PR DESCRIPTION
HAL tries to interpolate between dec bins when finding the detector response to convolve a point source with. However, sometimes we will provide a detector response file containing only one dec bin (e.g. for testing, or for specialized analyses). In that case, HAL should never try to interpolate, as the interpolation routine assumes there are at least two dec bins and crashes when provided with only one dec bin. This pull request fixes that problem.

