### PR TITLE
Futurizing hawc_hal for py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 
 # ROOT files
 .root
+
+# baks from futurize
+*.bak

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -53,15 +53,12 @@ class HAL(PluginPrototype):
         self._roi = roi
 
         # Set up the flat-sky projection
-
         self._flat_sky_projection = roi.get_flat_sky_projection(flat_sky_pixels_size)
 
         # Read map tree (data)
-
         self._maptree = map_tree_factory(maptree, roi=roi)
 
         # Read detector response_file
-
         self._response = hawc_response_factory(response_file)
 
         # Use a renormalization of the background as nuisance parameter

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import copy
 import collections
 
@@ -305,7 +309,7 @@ class HAL(PluginPrototype):
 
         # For each point source in the model, build the convolution class
 
-        for source in self._likelihood_model.point_sources.values():
+        for source in list(self._likelihood_model.point_sources.values()):
 
             this_convolved_point_source = ConvolvedPointSource(source, self._response, self._flat_sky_projection)
 
@@ -313,7 +317,7 @@ class HAL(PluginPrototype):
 
         # Samewise for extended sources
 
-        ext_sources = self._likelihood_model.extended_sources.values()
+        ext_sources = list(self._likelihood_model.extended_sources.values())
 
         # NOTE: ext_sources evaluate to False if empty
         if ext_sources:
@@ -397,9 +401,9 @@ class HAL(PluginPrototype):
                 yerr_low[i] = mean-y_low
                 yerr_high[i] = y_high-mean
 
-        residuals = (total_counts - total_model) / np.sqrt(total_model)
-        residuals_err = [yerr_high / np.sqrt(total_model),
-                         yerr_low / np.sqrt(total_model)]
+        residuals = old_div((total_counts - total_model), np.sqrt(total_model))
+        residuals_err = [old_div(yerr_high, np.sqrt(total_model)),
+                         old_div(yerr_low, np.sqrt(total_model))]
 
         yerr = [yerr_high, yerr_low]
 
@@ -466,7 +470,7 @@ class HAL(PluginPrototype):
             this_model_map_hpx = self._get_expectation(data_analysis_bin, bin_id, n_point_sources, n_ext_sources)
 
             # Now compare with observation
-            bkg_renorm = self._nuisance_parameters.values()[0].value
+            bkg_renorm = list(self._nuisance_parameters.values())[0].value
 
             obs = data_analysis_bin.observation_map.as_partial()  # type: np.array
             bkg = data_analysis_bin.background_map.as_partial() * bkg_renorm  # type: np.array
@@ -556,7 +560,7 @@ class HAL(PluginPrototype):
         # Now change name and return
         self._clone[0]._name = name
         # Adjust the name of the nuisance parameter
-        old_name = self._clone[0]._nuisance_parameters.keys()[0]
+        old_name = list(self._clone[0]._nuisance_parameters.keys())[0]
         new_name = old_name.replace(self.name, name)
         self._clone[0]._nuisance_parameters[new_name] = self._clone[0]._nuisance_parameters.pop(old_name)
 
@@ -631,7 +635,7 @@ class HAL(PluginPrototype):
         if this_model_map is not None:
 
             # First divide for the pixel area because we need to interpolate brightness
-            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
+            this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](this_model_map, fill_value=0.0)
 
@@ -657,7 +661,7 @@ class HAL(PluginPrototype):
         if smoothing_kernel_sigma is not None:
 
             # Get the sigma in pixels
-            sigma = smoothing_kernel_sigma * 60 / resolution
+            sigma = old_div(smoothing_kernel_sigma * 60, resolution)
 
             proj = convolve(list(proj),
                             Gaussian2DKernel(sigma),

--- a/hawc_hal/__init__.py
+++ b/hawc_hal/__init__.py
@@ -1,2 +1,3 @@
-from HAL import HAL
-from region_of_interest import *
+from __future__ import absolute_import
+from .HAL import HAL
+from .region_of_interest import *

--- a/hawc_hal/__init__.py
+++ b/hawc_hal/__init__.py
@@ -1,3 +1,2 @@
-from __future__ import absolute_import
 from .HAL import HAL
 from .region_of_interest import *

--- a/hawc_hal/convolved_source/__init__.py
+++ b/hawc_hal/convolved_source/__init__.py
@@ -1,3 +1,4 @@
-from convolved_source_container import ConvolvedSourcesContainer
-from convolved_point_source import ConvolvedPointSource
-from convolved_extended_source import ConvolvedExtendedSource2D, ConvolvedExtendedSource3D
+from __future__ import absolute_import
+from .convolved_source_container import ConvolvedSourcesContainer
+from .convolved_point_source import ConvolvedPointSource
+from .convolved_extended_source import ConvolvedExtendedSource2D, ConvolvedExtendedSource3D

--- a/hawc_hal/convolved_source/convolved_point_source.py
+++ b/hawc_hal/convolved_source/convolved_point_source.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from builtins import zip
+from builtins import object
+from past.utils import old_div
 import os
 import collections
 import numpy as np
@@ -118,12 +122,12 @@ class ConvolvedPointSource(object):
             sim_spectrum = [interp_sim_spectrum.integral(a, b) for (a, b) in zip(response_energy_bin.sim_energy_bin_low,
                                                                                  response_energy_bin.sim_energy_bin_hi)]
 
-            scale = np.array(src_spectrum) / np.array(sim_spectrum)
+            scale = old_div(np.array(src_spectrum), np.array(sim_spectrum))
 
         else:
 
             # Transform from keV^-1 cm^-2 s^-1 to TeV^-1 cm^-2 s^-1 and re-weight the detected counts
-            scale = source_diff_spectrum / response_energy_bin.sim_differential_photon_fluxes * 1e9
+            scale = old_div(source_diff_spectrum, response_energy_bin.sim_differential_photon_fluxes * 1e9)
 
         # Now return the map multiplied by the scale factor
         return np.sum(scale * response_energy_bin.sim_signal_events_per_bin) * this_map

--- a/hawc_hal/convolved_source/convolved_source_container.py
+++ b/hawc_hal/convolved_source/convolved_source_container.py
@@ -1,3 +1,4 @@
+from builtins import object
 class ConvolvedSourcesContainer(object):
     def __init__(self):
 

--- a/hawc_hal/flat_sky_projection.py
+++ b/hawc_hal/flat_sky_projection.py
@@ -1,9 +1,13 @@
+from __future__ import division
+from __future__ import absolute_import
+from builtins import object
+from past.utils import old_div
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_area
 import numpy as np
 
-from util import cartesian
+from .util import cartesian
 from hawc_hal.sphere_dist import sphere_dist
 
 
@@ -30,8 +34,8 @@ def _get_header(ra, dec, pixel_size, coordsys, h, w):
     assert 0 <= ra <= 360
 
     header = fits.Header.fromstring(_fits_header % (h, w,
-                                                    h / 2, ra, pixel_size,
-                                                    w / 2, dec, pixel_size,
+                                                    old_div(h, 2), ra, pixel_size,
+                                                    old_div(w, 2), dec, pixel_size,
                                                     coordsys),
                                     sep='\n')
 

--- a/hawc_hal/healpix_handling/__init__.py
+++ b/hawc_hal/healpix_handling/__init__.py
@@ -1,4 +1,5 @@
-from flat_sky_to_healpix import FlatSkyToHealpixTransform
-from sparse_healpix import SparseHealpix, DenseHealpix
-from gnomonic_projection import get_gnomonic_projection
-from healpix_utils import radec_to_vec
+from __future__ import absolute_import
+from .flat_sky_to_healpix import FlatSkyToHealpixTransform
+from .sparse_healpix import SparseHealpix, DenseHealpix
+from .gnomonic_projection import get_gnomonic_projection
+from .healpix_utils import radec_to_vec

--- a/hawc_hal/healpix_handling/flat_sky_to_healpix.py
+++ b/hawc_hal/healpix_handling/flat_sky_to_healpix.py
@@ -1,3 +1,4 @@
+from builtins import object
 import healpy as hp
 import numpy as np
 import six

--- a/hawc_hal/healpix_handling/gnomonic_projection.py
+++ b/hawc_hal/healpix_handling/gnomonic_projection.py
@@ -29,7 +29,7 @@ def get_gnomonic_projection(figure, hpx_map, **kwargs):
                 'cmap': None,
                 'norm': None}
 
-    for key, default_value in defaults.items():
+    for key, default_value in list(defaults.items()):
 
         if key not in kwargs:
 

--- a/hawc_hal/healpix_handling/sparse_healpix.py
+++ b/hawc_hal/healpix_handling/sparse_healpix.py
@@ -1,3 +1,4 @@
+from builtins import object
 import numpy as np
 import healpy as hp
 import pandas as pd

--- a/hawc_hal/interpolation/__init__.py
+++ b/hawc_hal/interpolation/__init__.py
@@ -1,2 +1,3 @@
-from fast_bilinar_interpolation import FastBilinearInterpolation
-from irregular_grid import FastLinearInterpolatorIrregularGrid  # pragma: no cover
+from __future__ import absolute_import
+from .fast_bilinar_interpolation import FastBilinearInterpolation
+from .irregular_grid import FastLinearInterpolatorIrregularGrid  # pragma: no cover

--- a/hawc_hal/interpolation/fast_bilinar_interpolation.py
+++ b/hawc_hal/interpolation/fast_bilinar_interpolation.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import object
+from past.utils import old_div
 import numpy as np
 
 from numba import jit
@@ -61,10 +64,10 @@ class FastBilinearInterpolation(object):
 
         bs = np.zeros((xx.shape[0], 4), np.float64)
 
-        bs[:, 0] = (x2 - xx) * (y2 - yy) / (x2 - x1) * (y2 - y1)
-        bs[:, 1] = (xx - x1) * (y2 - yy) / (x2 - x1) * (y2 - y1)
-        bs[:, 2] = (x2 - xx) * (yy - y1) / (x2 - x1) * (y2 - y1)
-        bs[:, 3] = (xx - x1) * (yy - y1) / (x2 - x1) * (y2 - y1)
+        bs[:, 0] = old_div((x2 - xx) * (y2 - yy), (x2 - x1) * (y2 - y1))
+        bs[:, 1] = old_div((xx - x1) * (y2 - yy), (x2 - x1) * (y2 - y1))
+        bs[:, 2] = old_div((x2 - xx) * (yy - y1), (x2 - x1) * (y2 - y1))
+        bs[:, 3] = old_div((xx - x1) * (yy - y1), (x2 - x1) * (y2 - y1))
 
         # Get the flat indexing for all the corners of the bounding boxes
         flat_upper_left = np.ravel_multi_index((x1, y1), self._data_shape)

--- a/hawc_hal/interpolation/irregular_grid.py
+++ b/hawc_hal/interpolation/irregular_grid.py
@@ -1,3 +1,4 @@
+from builtins import object
 import numpy as np
 from ..util import cartesian
 import scipy.spatial.qhull as qhull

--- a/hawc_hal/interpolation/log_log_interpolation.py
+++ b/hawc_hal/interpolation/log_log_interpolation.py
@@ -1,3 +1,4 @@
+from builtins import object
 import numpy as np
 from numpy import log10
 from math import log10 as mlog10

--- a/hawc_hal/maptree/__init__.py
+++ b/hawc_hal/maptree/__init__.py
@@ -1,1 +1,2 @@
-from map_tree import map_tree_factory
+from __future__ import absolute_import
+from .map_tree import map_tree_factory

--- a/hawc_hal/maptree/data_analysis_bin.py
+++ b/hawc_hal/maptree/data_analysis_bin.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import pandas as pd
 
 

--- a/hawc_hal/maptree/from_hdf5_file.py
+++ b/hawc_hal/maptree/from_hdf5_file.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import collections
 
 from hawc_hal.serialize import Serialization
@@ -6,7 +7,7 @@ from hawc_hal.region_of_interest import get_roi_from_dict
 from threeML.exceptions.custom_exceptions import custom_warnings
 
 from ..healpix_handling import SparseHealpix, DenseHealpix
-from data_analysis_bin import DataAnalysisBin
+from .data_analysis_bin import DataAnalysisBin
 
 
 def from_hdf5_file(map_tree_file, roi):

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from builtins import map
+from builtins import str
+from builtins import range
 import os
 import socket
 import collections
@@ -7,7 +11,7 @@ from threeML.io.file_utils import file_existing_and_readable, sanitize_filename
 from threeML.exceptions.custom_exceptions import custom_warnings
 
 from ..region_of_interest import HealpixROIBase
-from data_analysis_bin import DataAnalysisBin
+from .data_analysis_bin import DataAnalysisBin
 
 from ..healpix_handling import SparseHealpix, DenseHealpix
 
@@ -82,7 +86,7 @@ def from_root_file(map_tree_file, roi):
             except ValueError:
                 
                 # Give a useful error message
-                raise ValueError, "Maptree has no Branch: 'id' or 'name' "
+                raise ValueError("Maptree has no Branch: 'id' or 'name' ")
 
             # If the old style, we need to make them strings
             data_bins_labels = [ str(i) for i in data_bins_labels ]
@@ -181,7 +185,7 @@ def _read_partial_tree(ttree_instance, elements_to_read):
         entrylist = ROOT.TEntryList()
 
         # Add the selections
-        _ = map(entrylist.Enter, elements_to_read)
+        _ = list(map(entrylist.Enter, elements_to_read))
 
         # Apply the EntryList to the tree
         ttree_instance.SetEntryList(entrylist)

--- a/hawc_hal/maptree/map_tree.py
+++ b/hawc_hal/maptree/map_tree.py
@@ -1,3 +1,8 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import object
+from past.utils import old_div
 import os
 import numpy as np
 import pandas as pd
@@ -6,8 +11,8 @@ from threeML.io.rich_display import display
 from threeML.io.file_utils import sanitize_filename
 
 from ..serialize import Serialization
-from from_root_file import from_root_file
-from from_hdf5_file import from_hdf5_file
+from .from_root_file import from_root_file
+from .from_hdf5_file import from_hdf5_file
 
 import astropy.units as u
 
@@ -94,13 +99,13 @@ class MapTree(object):
     @property
     def analysis_bins_labels(self):
 
-        return self._analysis_bins.keys()
+        return list(self._analysis_bins.keys())
 
     def display(self):
 
         df = pd.DataFrame()
 
-        df['Bin'] = self._analysis_bins.keys()
+        df['Bin'] = list(self._analysis_bins.keys())
         df['Nside'] = [self._analysis_bins[bin_id].nside for bin_id in self._analysis_bins]
         df['Scheme'] = [self._analysis_bins[bin_id].scheme for bin_id in self._analysis_bins]
 
@@ -132,13 +137,13 @@ class MapTree(object):
 
         df['Obs counts'] = obs_counts
         df['Bkg counts'] = bkg_counts
-        df['obs/bkg'] = obs_counts / bkg_counts
+        df['obs/bkg'] = old_div(obs_counts, bkg_counts)
         df['Pixels in ROI'] = n_pixels
         df['Area (deg^2)'] = sky_area
 
         display(df)
 
-        first_bin_id = self._analysis_bins.keys()[0]
+        first_bin_id = list(self._analysis_bins.keys())[0]
         print("This Map Tree contains %.3f transits in the first bin" \
             % self._analysis_bins[first_bin_id].n_transits)
         print("Total data size: %.2f Mb" % (size * u.byte).to(u.megabyte).value)

--- a/hawc_hal/obsolete/fast_convolution.py
+++ b/hawc_hal/obsolete/fast_convolution.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 from numpy.fft import rfftn, irfftn
 from numpy import array, asarray, alltrue
 import numpy as np

--- a/hawc_hal/obsolete/tf1_wrapper.py
+++ b/hawc_hal/obsolete/tf1_wrapper.py
@@ -1,3 +1,4 @@
+from builtins import object
 class TF1Wrapper(object):
 
     def __init__(self, tf1_instance):

--- a/hawc_hal/obsolete/ts_map.py
+++ b/hawc_hal/obsolete/ts_map.py
@@ -1,3 +1,8 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from threeML import *
 import numpy as np
 import warnings
@@ -14,7 +19,7 @@ from threeML.parallel.parallel_client import ParallelClient, is_parallel_computa
 from threeML.io.progress_bar import progress_bar
 from threeML.io.fits_file import FITSFile
 
-crab_diff_flux_at_1_TeV = 2.65e-11 / (u.TeV * u.cm**2 * u.s)
+crab_diff_flux_at_1_TeV = old_div(2.65e-11, (u.TeV * u.cm**2 * u.s))
 
 
 class ParallelTSmap(object):
@@ -136,7 +141,7 @@ class ParallelTSmap(object):
                 
                 warnings.warn("The number of Dec bands is not a multiple of the number of engine. Make it so for optimal performances.", RuntimeWarning)
             
-            res = client.execute_with_progress_bar(self.worker, range(len(self._points)), chunk_size=self._n_ras)
+            res = client.execute_with_progress_bar(self.worker, list(range(len(self._points))), chunk_size=self._n_ras)
         
         else:
             

--- a/hawc_hal/psf_fast/__init__.py
+++ b/hawc_hal/psf_fast/__init__.py
@@ -1,3 +1,4 @@
-from psf_wrapper import PSFWrapper, InvalidPSF, InvalidPSFError
-from psf_interpolator import PSFInterpolator
-from psf_convolutor import PSFConvolutor
+from __future__ import absolute_import
+from .psf_wrapper import PSFWrapper, InvalidPSF, InvalidPSFError
+from .psf_interpolator import PSFInterpolator
+from .psf_convolutor import PSFConvolutor

--- a/hawc_hal/psf_fast/psf_convolutor.py
+++ b/hawc_hal/psf_fast/psf_convolutor.py
@@ -1,11 +1,16 @@
+from __future__ import division
+from __future__ import absolute_import
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import numpy as np
 from numpy.fft import rfftn, irfftn
 #from scipy.signal import fftconvolve
 from scipy.fftpack import helper
 
 
-from psf_interpolator import PSFInterpolator
-from psf_wrapper import PSFWrapper
+from .psf_interpolator import PSFInterpolator
+from .psf_wrapper import PSFWrapper
 
 
 class PSFConvolutor(object):
@@ -20,7 +25,7 @@ class PSFConvolutor(object):
         psf_stamp = interpolator.point_source_image(flat_sky_proj.ra_center, flat_sky_proj.dec_center)
 
         # Crop the kernel at the appropriate radius for this PSF (making sure is divisible by 2)
-        kernel_radius_px = int(np.ceil(self._psf.kernel_radius / flat_sky_proj.pixel_size))
+        kernel_radius_px = int(np.ceil(old_div(self._psf.kernel_radius, flat_sky_proj.pixel_size)))
         pixels_to_keep = kernel_radius_px * 2
 
         assert pixels_to_keep <= psf_stamp.shape[0] and \
@@ -35,7 +40,7 @@ class PSFConvolutor(object):
         assert np.isclose(self._kernel.sum(), 1.0, rtol=1e-2), "Failed to generate proper kernel normalization: got _kernel.sum() = %f; expected 1.0+-0.01." % self._kernel.sum()
 
         # Renormalize to exactly 1
-        self._kernel = self._kernel / self._kernel.sum()
+        self._kernel = old_div(self._kernel, self._kernel.sum())
 
         self._expected_shape = (flat_sky_proj.npix_height, flat_sky_proj.npix_width)
 

--- a/hawc_hal/psf_fast/psf_interpolator.py
+++ b/hawc_hal/psf_fast/psf_interpolator.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import object
+from past.utils import old_div
 import numpy as np
 import collections
 from hawc_hal import flat_sky_projection
@@ -36,7 +39,7 @@ class PSFInterpolator(object):
 
         # First we obtain an image with a flat sky projection centered exactly on the point source
         ancillary_image_pixel_size = 0.05
-        pixel_side = 2 * int(np.ceil(self._psf.truncation_radius / ancillary_image_pixel_size))
+        pixel_side = 2 * int(np.ceil(old_div(self._psf.truncation_radius, ancillary_image_pixel_size)))
         ancillary_flat_sky_proj = flat_sky_projection.FlatSkyProjection(ra, dec, ancillary_image_pixel_size,
                                                                         pixel_side, pixel_side)
 

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from builtins import zip
+from builtins import object
+from past.utils import old_div
 import numpy as np
 import scipy.interpolate
 import scipy.optimize
@@ -59,8 +63,7 @@ class PSFWrapper(object):
 
         # Compute the density
 
-        interp_y = np.array(map(lambda (a, b): self.integral(a, b) / (np.pi * (b ** 2 - a ** 2)) / self._total_integral,
-                                zip(self._xs[:-1], self._xs[1:])))
+        interp_y = np.array([old_div(self.integral(a_b[0], a_b[1]), (np.pi * (a_b[1] ** 2 - a_b[0] ** 2)) / self._total_integral) for a_b in zip(self._xs[:-1], self._xs[1:])])
 
         # Add zero at r = _INTEGRAL_OUTER_RADIUS so that the extrapolated values will be correct
         interp_x = np.append(interp_x, [_INTEGRAL_OUTER_RADIUS])
@@ -70,7 +73,7 @@ class PSFWrapper(object):
 
     def find_eef_radius(self, fraction):
 
-        f = lambda r: fraction - self.integral(1e-4, r) / self._total_integral
+        f = lambda r: fraction - old_div(self.integral(1e-4, r), self._total_integral)
 
         radius, status = scipy.optimize.brentq(f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output = True)
 
@@ -156,7 +159,7 @@ class PSFWrapper(object):
 
         # Make interpolation
         xs = np.logspace(-3, np.log10(_INTEGRAL_OUTER_RADIUS), 500)
-        ys = np.array(map(lambda x:tf1_instance.Eval(x), xs), float)
+        ys = np.array([tf1_instance.Eval(x) for x in xs], float)
 
         assert np.all(np.isfinite(xs))
         assert np.all(np.isfinite(ys))

--- a/hawc_hal/region_of_interest/healpix_cone_roi.py
+++ b/hawc_hal/region_of_interest/healpix_cone_roi.py
@@ -1,7 +1,11 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from past.utils import old_div
 import numpy as np
 import astropy.units as u
 import healpy as hp
-from healpix_roi_base import HealpixROIBase, _RING, _NESTED
+from .healpix_roi_base import HealpixROIBase, _RING, _NESTED
 
 from astromodels.core.sky_direction import SkyDirection
 
@@ -123,7 +127,7 @@ class HealpixConeROI(HealpixROIBase):
         # Decide side for image
 
         # Compute number of pixels, making sure it is going to be even (by approximating up)
-        npix_per_side = 2 * int(np.ceil(np.rad2deg(self._model_radius_radians) / pixel_size_deg))
+        npix_per_side = 2 * int(np.ceil(old_div(np.rad2deg(self._model_radius_radians), pixel_size_deg)))
 
         # Get lon, lat of center
         ra, dec = self._get_ra_dec()

--- a/hawc_hal/region_of_interest/healpix_map_roi.py
+++ b/hawc_hal/region_of_interest/healpix_map_roi.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 import numpy as np
 import astropy.units as u
 import healpy as hp
@@ -151,7 +154,7 @@ class HealpixMapROI(HealpixROIBase):
         # Decide side for image
 
         # Compute number of pixels, making sure it is going to be even (by approximating up)
-        npix_per_side = 2 * int(np.ceil(np.rad2deg(self._model_radius_radians) / pixel_size_deg))
+        npix_per_side = 2 * int(np.ceil(old_div(np.rad2deg(self._model_radius_radians), pixel_size_deg)))
 
         # Get lon, lat of center
         ra, dec = self._get_ra_dec()

--- a/hawc_hal/region_of_interest/healpix_roi_base.py
+++ b/hawc_hal/region_of_interest/healpix_roi_base.py
@@ -1,3 +1,4 @@
+from builtins import object
 _EQUATORIAL = 'equatorial'
 _GALACTIC = 'galactic'
 

--- a/hawc_hal/response/__init__.py
+++ b/hawc_hal/response/__init__.py
@@ -1,1 +1,2 @@
-from response import hawc_response_factory
+from __future__ import absolute_import
+from .response import hawc_response_factory

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -1,3 +1,10 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import zip
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import numpy as np
 import pandas as pd
 import os
@@ -9,7 +16,7 @@ from threeML.io.file_utils import file_existing_and_readable, sanitize_filename
 from threeML.exceptions.custom_exceptions import custom_warnings
 
 from ..psf_fast import PSFWrapper
-from response_bin import ResponseBin
+from .response_bin import ResponseBin
 
 _instances = {}
 
@@ -141,7 +148,7 @@ class HAWCResponse(object):
 
             response_bins[dec_center] = these_response_bins
 
-        dec_bins = zip(min_decs, declination_centers, max_decs)
+        dec_bins = list(zip(min_decs, declination_centers, max_decs))
 
         return cls(response_file_name, dec_bins, response_bins)
 
@@ -189,7 +196,7 @@ class HAWCResponse(object):
             dec_bins_upper_edge = dec_bins_['upperEdge']  # type: np.ndarray
             dec_bins_center = dec_bins_['simdec']  # type: np.ndarray
 
-            dec_bins = zip(dec_bins_lower_edge, dec_bins_center, dec_bins_upper_edge)
+            dec_bins = list(zip(dec_bins_lower_edge, dec_bins_center, dec_bins_upper_edge))
 
             # Read in the ids of the response bins ("analysis bins" in LiFF jargon)
             try:
@@ -229,7 +236,7 @@ class HAWCResponse(object):
 
                     n_energy_bins = root_file.Get(dec_id_label).GetNkeys()
 
-                    response_bins_ids = range(n_energy_bins)
+                    response_bins_ids = list(range(n_energy_bins))
 
                 for response_bin_id in response_bins_ids:
                     this_response_bin = ResponseBin.from_ttree(root_file, dec_id, response_bin_id, log_log_spectrum,
@@ -257,7 +264,7 @@ class HAWCResponse(object):
         """
 
         # Sort declination bins by distance to the provided declination
-        dec_bins_keys = self._response_bins.keys()
+        dec_bins_keys = list(self._response_bins.keys())
         dec_bins_by_distance = sorted(dec_bins_keys, key=lambda x: abs(x - dec))
 
         if not interpolate:
@@ -286,8 +293,8 @@ class HAWCResponse(object):
             # Now linearly interpolate between them
 
             # Compute the weights according to the distance to the source
-            w1 = (dec - dec_bin_two) / (dec_bin_one - dec_bin_two)
-            w2 = (dec - dec_bin_one) / (dec_bin_two - dec_bin_one)
+            w1 = old_div((dec - dec_bin_two), (dec_bin_one - dec_bin_two))
+            w2 = old_div((dec - dec_bin_one), (dec_bin_two - dec_bin_one))
 
             new_responses = collections.OrderedDict()
 
@@ -311,7 +318,7 @@ class HAWCResponse(object):
     @property
     def n_energy_planes(self):
 
-        return len(self._response_bins.values()[0])
+        return len(list(self._response_bins.values())[0])
 
     def display(self, verbose=False):
         """
@@ -323,10 +330,10 @@ class HAWCResponse(object):
         print("Response file: %s" % self._response_file_name)
         print("Number of dec bins: %s" % len(self._dec_bins))
         if verbose:
-            print self._dec_bins
+            print(self._dec_bins)
         print("Number of energy/nHit planes per dec bin_name: %s" % (self.n_energy_planes))
         if verbose:
-            print self._response_bins.values()[0].keys()
+            print(list(self._response_bins.values())[0].keys())
 
     def write(self, filename):
         """
@@ -339,7 +346,7 @@ class HAWCResponse(object):
         filename = sanitize_filename(filename)
 
         # Unravel the dec bins
-        min_decs, center_decs, max_decs = zip(*self._dec_bins)
+        min_decs, center_decs, max_decs = list(zip(*self._dec_bins))
 
         # We get the definition of the response bins, as well as their coordinates (the dec center) and store them
         # in lists. Later on we will use these to make 3 dataframes containing all the needed data

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import numpy as np
 import pandas as pd
 

--- a/hawc_hal/serialize.py
+++ b/hawc_hal/serialize.py
@@ -1,3 +1,4 @@
+from builtins import object
 from pandas import HDFStore
 
 
@@ -30,7 +31,7 @@ class Serialization(object):
     @property
     def keys(self):
 
-        return self._store.keys()
+        return list(self._store.keys())
 
     def store_pandas_object(self, path, obj, **metadata):
 

--- a/hawc_hal/util.py
+++ b/hawc_hal/util.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 
 
@@ -23,7 +26,7 @@ def cartesian_(arrays, out=None):
 
         out = np.zeros([n, len(arrays)], dtype=dtype)
 
-    m = n / arrays[0].size
+    m = old_div(n, arrays[0].size)
     out[:,0] = np.repeat(arrays[0], m)
 
     if arrays[1:]:

--- a/scripts/hal_fit_point_source.py
+++ b/scripts/hal_fit_point_source.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 # If ROOT is active, we need to skip its own command line parsing
+from builtins import map
+from builtins import range
 try:
 
     import ROOT
@@ -63,7 +65,7 @@ if __name__ == "__main__":
     parser.add_argument("--params", help="Parameter specification. For example, for the Power_law spectrum, "
                                          "you can use: '2e.5e-11 1/(TeV cm2 s)' '-2.0'", required=True)
     parser.add_argument("--bin_list", help="Bin list to use for analysis", required=False,
-                        default=map(str, range(1, 10)),
+                        default=list(map(str, list(range(1, 10)))),
                         nargs='+')
     parser.add_argument("--display_model", help="Whether to display or not the model before fitting",
                         action="store_true", default=False)

--- a/scripts/hal_hdf5_to_fits.py
+++ b/scripts/hal_hdf5_to_fits.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import range
 from hawc_hal.maptree import map_tree_factory
 from astropy.io import fits
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 import matplotlib
 matplotlib.use("Agg")
 
@@ -94,12 +97,12 @@ def check_responses(r1, r2):
 
     assert len(r1.response_bins) == len(r2.response_bins)
 
-    for resp_key in r1.response_bins.keys():
+    for resp_key in list(r1.response_bins.keys()):
 
         rbb1 = r1.response_bins[resp_key]
         rbb2 = r2.response_bins[resp_key]
 
-        assert len(rbb1.keys()) == len(rbb2.keys())
+        assert len(list(rbb1.keys())) == len(list(rbb2.keys()))
 
         for rb_key in rbb1:
 
@@ -214,7 +217,7 @@ def point_source_model(ra=83.6279, dec=22.14):
 
     spectrum.piv.fix = True
 
-    spectrum.K = 3.15e-11 / (u.TeV * u.cm ** 2 * u.s)  # norm (in 1/(keV cm2 s))
+    spectrum.K = old_div(3.15e-11, (u.TeV * u.cm ** 2 * u.s))  # norm (in 1/(keV cm2 s))
     spectrum.K.bounds = (1e-23, 1e-17)  # without units energies are in keV
 
     spectrum.index = -2.0

--- a/tests/test_complete_analysis.py
+++ b/tests/test_complete_analysis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from hawc_hal import HAL
 import matplotlib.pyplot as plt
 from threeML import *
@@ -147,7 +148,7 @@ def test_bayesian_analysis(test_fit):
     pts_model.pts.position.dec.free = False
 
     # For this quick example, let's use a uniform prior for all parameters
-    for parameter in pts_model.parameters.values():
+    for parameter in list(pts_model.parameters.values()):
 
         if parameter.fix:
             continue

--- a/tests/test_geminga_paper.py
+++ b/tests/test_geminga_paper.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from hawc_hal import HAL, HealpixConeROI
 
 try:

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import pytest
 from os.path import dirname
 from hawc_hal import HealpixConeROI, HAL
@@ -40,7 +42,7 @@ def test_model_residual_maps(geminga_maptree, geminga_response, geminga_roi):
     spectrum1 = Powerlaw()
     source1 = PointSource("point", ra=ra_src + pt_shift, dec=dec_src, spectral_shape=spectrum1)
 
-    spectrum1.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s)
+    spectrum1.K = old_div(1e-12, (u.TeV * u.cm ** 2 * u.s))
     spectrum1.piv = 1 * u.TeV
     spectrum1.index = -2.3
 
@@ -53,7 +55,7 @@ def test_model_residual_maps(geminga_maptree, geminga_response, geminga_roi):
     spectrum2 = Powerlaw()
     source2 = ExtendedSource("extended", spatial_shape=shape, spectral_shape=spectrum2)
 
-    spectrum2.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s) 
+    spectrum2.K = old_div(1e-12, (u.TeV * u.cm ** 2 * u.s)) 
     spectrum2.piv = 1 * u.TeV
     spectrum2.index = -2.0  
 

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import pytest
 from hawc_hal.psf_fast import InvalidPSF, InvalidPSFError
@@ -11,4 +12,4 @@ def test_invalid_psf():
 
     # Check that another method raises the desired error
     with pytest.raises(InvalidPSFError):
-        print cpsf.repr()
+        print(cpsf.repr())

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,3 +1,4 @@
+from builtins import range
 from hawc_hal import serialize
 import pandas as pd
 import numpy as np
@@ -6,7 +7,7 @@ import os
 
 def test_serialization():
 
-    my_obj = pd.Series(range(100))
+    my_obj = pd.Series(list(range(100)))
     my_ob2 = pd.DataFrame.from_dict({'one': np.random.uniform(0, 1, 10), 'two': np.random.uniform(0, 1, 10)})
 
     meta = {'meta1': 1.0, 'meta2': 2.0}


### PR DESCRIPTION
I use the `futurize` software to start making changes for `hawc_hal` to be able to run in py3. 
I was able to compile it in the miniconda3 environment and it seemed to install fine, and least it didn't give me syntax errors. 

I ran the tests with `pytest` (version 5.4.2). A few tests ran fine. I got one test (`test_copy.py`) that didn't pass due to the newer pytest version. I'm not very verse with pytest but I can keep looking into it. Other tests gave me some weird errors, like a ROOT file not being able  to close (when running `test_geminga_paper` for example). 

I still figure it would be good to start the conversion of hawc_hal to py3.
I'm requesting to merge to the master branch, but if any of the threeML group would like to make a py3 branch so that I can pull request there, that would work too, and more interested people could also look into updating the code. 