### PR TITLE
Deleting all the `old_div` appearances in hawc_hal

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -3,7 +3,6 @@ from __future__ import division
 
 from builtins import str
 from builtins import range
-from past.utils import old_div
 import copy
 import collections
 
@@ -398,9 +397,9 @@ class HAL(PluginPrototype):
                 yerr_low[i] = mean-y_low
                 yerr_high[i] = y_high-mean
 
-        residuals = old_div((total_counts - total_model), np.sqrt(total_model))
-        residuals_err = [old_div(yerr_high, np.sqrt(total_model)),
-                         old_div(yerr_low, np.sqrt(total_model))]
+        residuals = (total_counts - total_model) / np.sqrt(total_model)
+        residuals_err = [yerr_high / np.sqrt(total_model),
+                         yerr_low / np.sqrt(total_model)]
 
         yerr = [yerr_high, yerr_low]
 
@@ -632,7 +631,7 @@ class HAL(PluginPrototype):
         if this_model_map is not None:
 
             # First divide for the pixel area because we need to interpolate brightness
-            this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
+            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](this_model_map, fill_value=0.0)
 
@@ -658,7 +657,7 @@ class HAL(PluginPrototype):
         if smoothing_kernel_sigma is not None:
 
             # Get the sigma in pixels
-            sigma = old_div(smoothing_kernel_sigma * 60, resolution)
+            sigma = smoothing_kernel_sigma * 60 / resolution
 
             proj = convolve(list(proj),
                             Gaussian2DKernel(sigma),

--- a/hawc_hal/convolved_source/convolved_extended_source.py
+++ b/hawc_hal/convolved_source/convolved_extended_source.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from __future__ import print_function
 from builtins import zip
-from past.utils import old_div
 from builtins import object
 import numpy as np
 
@@ -184,11 +183,11 @@ class ConvolvedExtendedSource3D(ConvolvedExtendedSource):
                 # NOTE: the scale is the same because the sim_differential_photon_fluxes are the same (the simulation
                 # used to make the response used the same spectrum for each bin). What changes between the two bins
                 # is the observed signal per bin (the .sim_signal_events_per_bin member)
-                scale = old_div((self._all_fluxes[idx, :] * pixel_area_rad2), this_response_bin1.sim_differential_photon_fluxes)
+                scale = (self._all_fluxes[idx, :] * pixel_area_rad2) / this_response_bin1.sim_differential_photon_fluxes
 
                 # Compute the interpolation weights for the two responses
-                w1 = old_div((self._flat_sky_projection.decs[idx] - c2), (c1 - c2))
-                w2 = old_div((self._flat_sky_projection.decs[idx] - c1), (c2 - c1))
+                w1 = (self._flat_sky_projection.decs[idx] - c2) / (c1 - c2)
+                w2 = (self._flat_sky_projection.decs[idx] - c1) / (c2 - c1)
 
                 this_model_image[idx] = (w1 * np.sum(scale * this_response_bin1.sim_signal_events_per_bin, axis=1) +
                                          w2 * np.sum(scale * this_response_bin2.sim_signal_events_per_bin, axis=1)) * \

--- a/hawc_hal/convolved_source/convolved_point_source.py
+++ b/hawc_hal/convolved_source/convolved_point_source.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from builtins import zip
 from builtins import object
-from past.utils import old_div
 import os
 import collections
 import numpy as np
@@ -122,12 +121,12 @@ class ConvolvedPointSource(object):
             sim_spectrum = [interp_sim_spectrum.integral(a, b) for (a, b) in zip(response_energy_bin.sim_energy_bin_low,
                                                                                  response_energy_bin.sim_energy_bin_hi)]
 
-            scale = old_div(np.array(src_spectrum), np.array(sim_spectrum))
+            scale = np.array(src_spectrum) / np.array(sim_spectrum)
 
         else:
 
             # Transform from keV^-1 cm^-2 s^-1 to TeV^-1 cm^-2 s^-1 and re-weight the detected counts
-            scale = old_div(source_diff_spectrum, response_energy_bin.sim_differential_photon_fluxes * 1e9)
+            scale = source_diff_spectrum / response_energy_bin.sim_differential_photon_fluxes * 1e9
 
         # Now return the map multiplied by the scale factor
         return np.sum(scale * response_energy_bin.sim_signal_events_per_bin) * this_map

--- a/hawc_hal/flat_sky_projection.py
+++ b/hawc_hal/flat_sky_projection.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from __future__ import absolute_import
 from builtins import object
-from past.utils import old_div
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_area
@@ -34,8 +33,8 @@ def _get_header(ra, dec, pixel_size, coordsys, h, w):
     assert 0 <= ra <= 360
 
     header = fits.Header.fromstring(_fits_header % (h, w,
-                                                    old_div(h, 2), ra, pixel_size,
-                                                    old_div(w, 2), dec, pixel_size,
+                                                    h / 2, ra, pixel_size,
+                                                    w / 2, dec, pixel_size,
                                                     coordsys),
                                     sep='\n')
 

--- a/hawc_hal/interpolation/fast_bilinar_interpolation.py
+++ b/hawc_hal/interpolation/fast_bilinar_interpolation.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import object
-from past.utils import old_div
 import numpy as np
 
 from numba import jit
@@ -64,10 +63,10 @@ class FastBilinearInterpolation(object):
 
         bs = np.zeros((xx.shape[0], 4), np.float64)
 
-        bs[:, 0] = old_div((x2 - xx) * (y2 - yy), (x2 - x1) * (y2 - y1))
-        bs[:, 1] = old_div((xx - x1) * (y2 - yy), (x2 - x1) * (y2 - y1))
-        bs[:, 2] = old_div((x2 - xx) * (yy - y1), (x2 - x1) * (y2 - y1))
-        bs[:, 3] = old_div((xx - x1) * (yy - y1), (x2 - x1) * (y2 - y1))
+        bs[:, 0] = (x2 - xx) * (y2 - yy) / (x2 - x1) * (y2 - y1)
+        bs[:, 1] = (xx - x1) * (y2 - yy) / (x2 - x1) * (y2 - y1)
+        bs[:, 2] = (x2 - xx) * (yy - y1) / (x2 - x1) * (y2 - y1)
+        bs[:, 3] = (xx - x1) * (yy - y1) / (x2 - x1) * (y2 - y1)
 
         # Get the flat indexing for all the corners of the bounding boxes
         flat_upper_left = np.ravel_multi_index((x1, y1), self._data_shape)

--- a/hawc_hal/maptree/map_tree.py
+++ b/hawc_hal/maptree/map_tree.py
@@ -2,7 +2,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import object
-from past.utils import old_div
 import os
 import numpy as np
 import pandas as pd
@@ -137,7 +136,7 @@ class MapTree(object):
 
         df['Obs counts'] = obs_counts
         df['Bkg counts'] = bkg_counts
-        df['obs/bkg'] = old_div(obs_counts, bkg_counts)
+        df['obs/bkg'] = obs_counts / bkg_counts
         df['Pixels in ROI'] = n_pixels
         df['Area (deg^2)'] = sky_area
 

--- a/hawc_hal/obsolete/ts_map.py
+++ b/hawc_hal/obsolete/ts_map.py
@@ -2,7 +2,6 @@ from __future__ import division
 from __future__ import print_function
 from builtins import range
 from builtins import object
-from past.utils import old_div
 from threeML import *
 import numpy as np
 import warnings
@@ -19,7 +18,7 @@ from threeML.parallel.parallel_client import ParallelClient, is_parallel_computa
 from threeML.io.progress_bar import progress_bar
 from threeML.io.fits_file import FITSFile
 
-crab_diff_flux_at_1_TeV = old_div(2.65e-11, (u.TeV * u.cm**2 * u.s))
+crab_diff_flux_at_1_TeV = 2.65e-11 / (u.TeV * u.cm**2 * u.s)
 
 
 class ParallelTSmap(object):

--- a/hawc_hal/psf_fast/psf_convolutor.py
+++ b/hawc_hal/psf_fast/psf_convolutor.py
@@ -2,7 +2,6 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import range
 from builtins import object
-from past.utils import old_div
 import numpy as np
 from numpy.fft import rfftn, irfftn
 #from scipy.signal import fftconvolve
@@ -25,7 +24,7 @@ class PSFConvolutor(object):
         psf_stamp = interpolator.point_source_image(flat_sky_proj.ra_center, flat_sky_proj.dec_center)
 
         # Crop the kernel at the appropriate radius for this PSF (making sure is divisible by 2)
-        kernel_radius_px = int(np.ceil(old_div(self._psf.kernel_radius, flat_sky_proj.pixel_size)))
+        kernel_radius_px = int(np.ceil(self._psf.kernel_radius / flat_sky_proj.pixel_size))
         pixels_to_keep = kernel_radius_px * 2
 
         assert pixels_to_keep <= psf_stamp.shape[0] and \
@@ -40,7 +39,7 @@ class PSFConvolutor(object):
         assert np.isclose(self._kernel.sum(), 1.0, rtol=1e-2), "Failed to generate proper kernel normalization: got _kernel.sum() = %f; expected 1.0+-0.01." % self._kernel.sum()
 
         # Renormalize to exactly 1
-        self._kernel = old_div(self._kernel, self._kernel.sum())
+        self._kernel = self._kernel / self._kernel.sum()
 
         self._expected_shape = (flat_sky_proj.npix_height, flat_sky_proj.npix_width)
 

--- a/hawc_hal/psf_fast/psf_interpolator.py
+++ b/hawc_hal/psf_fast/psf_interpolator.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import object
-from past.utils import old_div
 import numpy as np
 import collections
 from hawc_hal import flat_sky_projection
@@ -39,7 +38,7 @@ class PSFInterpolator(object):
 
         # First we obtain an image with a flat sky projection centered exactly on the point source
         ancillary_image_pixel_size = 0.05
-        pixel_side = 2 * int(np.ceil(old_div(self._psf.truncation_radius, ancillary_image_pixel_size)))
+        pixel_side = 2 * int(np.ceil(self._psf.truncation_radius / ancillary_image_pixel_size))
         ancillary_flat_sky_proj = flat_sky_projection.FlatSkyProjection(ra, dec, ancillary_image_pixel_size,
                                                                         pixel_side, pixel_side)
 

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from builtins import zip
 from builtins import object
-from past.utils import old_div
 import numpy as np
 import scipy.interpolate
 import scipy.optimize
@@ -63,7 +62,7 @@ class PSFWrapper(object):
 
         # Compute the density
 
-        interp_y = np.array([old_div(self.integral(a_b[0], a_b[1]), (np.pi * (a_b[1] ** 2 - a_b[0] ** 2)) / self._total_integral) for a_b in zip(self._xs[:-1], self._xs[1:])])
+        interp_y = np.array([self.integral(a_b[0], a_b[1]) / (np.pi * (a_b[1] ** 2 - a_b[0] ** 2)) / self._total_integral for a_b in zip(self._xs[:-1], self._xs[1:])])
 
         # Add zero at r = _INTEGRAL_OUTER_RADIUS so that the extrapolated values will be correct
         interp_x = np.append(interp_x, [_INTEGRAL_OUTER_RADIUS])
@@ -73,7 +72,7 @@ class PSFWrapper(object):
 
     def find_eef_radius(self, fraction):
 
-        f = lambda r: fraction - old_div(self.integral(1e-4, r), self._total_integral)
+        f = lambda r: fraction - self.integral(1e-4, r) / self._total_integral
 
         radius, status = scipy.optimize.brentq(f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output = True)
 

--- a/hawc_hal/region_of_interest/healpix_cone_roi.py
+++ b/hawc_hal/region_of_interest/healpix_cone_roi.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from past.utils import old_div
 import numpy as np
 import astropy.units as u
 import healpy as hp
@@ -127,7 +126,7 @@ class HealpixConeROI(HealpixROIBase):
         # Decide side for image
 
         # Compute number of pixels, making sure it is going to be even (by approximating up)
-        npix_per_side = 2 * int(np.ceil(old_div(np.rad2deg(self._model_radius_radians), pixel_size_deg)))
+        npix_per_side = 2 * int(np.ceil(np.rad2deg(self._model_radius_radians) / pixel_size_deg))
 
         # Get lon, lat of center
         ra, dec = self._get_ra_dec()

--- a/hawc_hal/region_of_interest/healpix_map_roi.py
+++ b/hawc_hal/region_of_interest/healpix_map_roi.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from __future__ import print_function
-from past.utils import old_div
 import numpy as np
 import astropy.units as u
 import healpy as hp
@@ -154,7 +153,7 @@ class HealpixMapROI(HealpixROIBase):
         # Decide side for image
 
         # Compute number of pixels, making sure it is going to be even (by approximating up)
-        npix_per_side = 2 * int(np.ceil(old_div(np.rad2deg(self._model_radius_radians), pixel_size_deg)))
+        npix_per_side = 2 * int(np.ceil(np.rad2deg(self._model_radius_radians) / pixel_size_deg))
 
         # Get lon, lat of center
         ra, dec = self._get_ra_dec()

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from builtins import zip
 from builtins import range
 from builtins import object
-from past.utils import old_div
 import numpy as np
 import pandas as pd
 import os
@@ -293,8 +292,8 @@ class HAWCResponse(object):
             # Now linearly interpolate between them
 
             # Compute the weights according to the distance to the source
-            w1 = old_div((dec - dec_bin_two), (dec_bin_one - dec_bin_two))
-            w2 = old_div((dec - dec_bin_one), (dec_bin_two - dec_bin_one))
+            w1 = (dec - dec_bin_two) / (dec_bin_one - dec_bin_two)
+            w2 = (dec - dec_bin_one) / (dec_bin_two - dec_bin_one)
 
             new_responses = collections.OrderedDict()
 

--- a/hawc_hal/util.py
+++ b/hawc_hal/util.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 
 
@@ -26,7 +25,7 @@ def cartesian_(arrays, out=None):
 
         out = np.zeros([n, len(arrays)], dtype=dtype)
 
-    m = old_div(n, arrays[0].size)
+    m = n / arrays[0].size
     out[:,0] = np.repeat(arrays[0], m)
 
     if arrays[1:]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from __future__ import print_function
-from past.utils import old_div
 import matplotlib
 matplotlib.use("Agg")
 
@@ -217,7 +216,8 @@ def point_source_model(ra=83.6279, dec=22.14):
 
     spectrum.piv.fix = True
 
-    spectrum.K = old_div(3.15e-11, (u.TeV * u.cm ** 2 * u.s))  # norm (in 1/(keV cm2 s))
+    spectrum.K = 3.15e-11 / (u.TeV * u.cm ** 2 * u.s)  # norm (in 1/(keV cm2 s))
+
     spectrum.K.bounds = (1e-23, 1e-17)  # without units energies are in keV
 
     spectrum.index = -2.0

--- a/tests/test_model_residual_maps.py
+++ b/tests/test_model_residual_maps.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from past.utils import old_div
 import pytest
 from os.path import dirname
 from hawc_hal import HealpixConeROI, HAL
@@ -42,7 +41,7 @@ def test_model_residual_maps(geminga_maptree, geminga_response, geminga_roi):
     spectrum1 = Powerlaw()
     source1 = PointSource("point", ra=ra_src + pt_shift, dec=dec_src, spectral_shape=spectrum1)
 
-    spectrum1.K = old_div(1e-12, (u.TeV * u.cm ** 2 * u.s))
+    spectrum1.K = 1e-12 / (u.TeV * u.cm ** 2 * u.s)
     spectrum1.piv = 1 * u.TeV
     spectrum1.index = -2.3
 
@@ -55,7 +54,7 @@ def test_model_residual_maps(geminga_maptree, geminga_response, geminga_roi):
     spectrum2 = Powerlaw()
     source2 = ExtendedSource("extended", spatial_shape=shape, spectral_shape=spectrum2)
 
-    spectrum2.K = old_div(1e-12, (u.TeV * u.cm ** 2 * u.s)) 
+    spectrum2.K = 1e-12  (u.TeV * u.cm ** 2 * u.s)
     spectrum2.piv = 1 * u.TeV
     spectrum2.index = -2.0  
 


### PR DESCRIPTION
I deleted all the appearances of `old_div` inside hawc_hal. I know @ndilalla run some tests and was able to pinpoint the problem when running HAL with the public HAWC data. So if this PR is not necessary let me know.

I tested this repo and I was able to get the same results as @ndilalla. However, I was not able to get the figures with the environment that I was using. It is the environment that we use to install 3ML in HAWC (@cbrisboi might have more info). After talking with @cbrisboi it seems there are other py2-py3 non-trivial issues so not getting the figures might be related to that. 