### PR TITLE
Remove py2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ env:
 jobs:
   include:
   - os: linux
-    python: 2.7
-    env: TRAVIS_PYTHON_VERSION=2.7
-  - os: osx
-    python: 2.7
-    env: TRAVIS_PYTHON_VERSION=2.7
-  - os: linux
     python: 3.7
     env: TRAVIS_PYTHON_VERSION=3.7
   - os: osx

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
               'hawc_hal/region_of_interest',
               'hawc_hal/convenience_functions'],
 
-    url='https://github.com/giacomov/hawc_hal',
+    url='https://github.com/threeML/hawc_hal',
 
     license='BSD-3.0',
 


### PR DESCRIPTION
Remove python2.7 from the automated tests, as it is no longer supported.
