### PR TITLE
Switch parameter names in Line function

### DIFF
--- a/tests/test_geminga_paper.py
+++ b/tests/test_geminga_paper.py
@@ -13,7 +13,6 @@ import argparse
 from collections import namedtuple
 import pytest
 
-@pytest.mark.xfail
 def test_geminga_paper(geminga_maptree, geminga_response):
 
     Args_fake = namedtuple('args', 'mtfile,rsfile,startBin,stopBin,RA,Dec,uratio,delta,ROI,output,plugin')
@@ -171,7 +170,7 @@ def go(args):
 
     # we fit a common diffusion coefficient so parameters are linked
     if "B0656" in lm and "Geminga" in lm:
-        law = Line(a=250. / 288., b=0.)
+        law = Line(b=250. / 288., a=0.)
         lm.link(lm.B0656.spatial_shape.rdiff0,
                 lm.Geminga.spatial_shape.rdiff0,
                 law)


### PR DESCRIPTION
Fixes #49 

Parameters `a` and `b` were switched in the astromodels `Line` function which is used to link the diffusion radii of Geminga and Monogem. This is now taken into account in the Geminga test, which now passes again. 