### PR TITLE
Half-Fix CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,7 @@ jobs:
 
                   PKG="pytest>=3.6 pandas>=0.23 ultranest interpolation>=2.1.5"
 
-                  conda install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
+                  mamba install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
                   pip install --no-binary :all: root_numpy
             - name: Conda list
               shell: bash -l {0}
@@ -195,7 +195,7 @@ jobs:
 
                   PKG="pytest>=3.6 pandas>=0.23 ultranest interpolation>=2.1.5"
 
-                  conda install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
+                  mamba install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
                   pip install --no-binary :all: root_numpy
                   pip uninstall astromodels threeML -y
                   pip install git+https://github.com/threeml/astromodels.git

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,7 @@ jobs:
                   if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
                   if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
                   if [ -n "${XSPECVER}" ];
-                  then export XSPEC="xspec-modelsonly=${XSPECVER} ${xorg}";
+                  then export XSPEC="xspec-modelsonly>=${XSPECVER} ${xorg}";
                   fi
 
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,7 +57,7 @@ jobs:
                   if [[ ${{matrix.os}} == ubuntu-latest ]];
                   then
                   miniconda_os=Linux
-                  compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
+                  compilers="gcc_linux-64 gxx_linux-64"
                   else  # osx
                   miniconda_os=MacOSX
                   compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
@@ -130,7 +130,7 @@ jobs:
                   if [[ ${{matrix.os}} == ubuntu-latest ]];
                   then
                   miniconda_os=Linux
-                  compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
+                  compilers="gcc_linux-64 gxx_linux-64"
                   else  # osx
                   miniconda_os=MacOSX
                   compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,40 +61,12 @@ jobs:
                   else  # osx
                   miniconda_os=MacOSX
                   compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
-
-                  # On macOS we also need the conda libx11 libraries used to build xspec
-                  # We also need to pin down ncurses, for now only on macos.
-                  xorg="xorg-libx11"
                   fi
-
-                  # Get the version in the __version__ environment variable
-                  #python ci/set_minor_version.py --patch $TRAVIS_BUILD_NUMBER --version_file threeML/version.py
-
-                  #export PKG_VERSION=$(cd threeML && python -c "import version;print(version.__version__)")
-
-                  export PKG_VERSION=$(python -c "import versioneer;print(versioneer.get_version())")
 
                   echo "HOME= ${HOME}"
-                  echo "Building ${PKG_VERSION} ..."
                   echo "Python version: ${{matrix.python-version}}"
 
-                  #libgfortranver="3.0"
-                  #NUMPYVER=1.15
-                  MATPLOTLIBVER=2
-                  XSPECVER="6.25"
-                  xspec_channel=xspecmodels
-
-                  # Figure out requested dependencies
-                  if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
-                  if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
-                  if [ -n "${XSPECVER}" ];
-                  then export XSPEC="xspec-modelsonly>=${XSPECVER} ${xorg}";
-                  fi
-
-
-                  PKG="pytest>=3.6 pandas>=0.23 ultranest interpolation>=2.1.5"
-
-                  mamba install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
+                  mamba install pytest codecov pytest-cov git matplotlib numpy astropy ${compilers} scipy astropy astromodels threeML numba reproject root flake8
                   pip install --no-binary :all: root_numpy
             - name: Conda list
               shell: bash -l {0}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,8 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   channels: conda-forge, xspecmodels, threeml, defaults
                   environment-file: ci/environment.yml
-
+                  mamba-version: "*"
+                  
             - name: Init Env
               shell: bash -l {0}
               run: |
@@ -148,7 +149,8 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   channels: conda-forge, xspecmodels, threeml, defaults
                   environment-file: ci/environment.yml
-
+                  mamba-version: "*"
+                  
             - name: Init Env
               shell: bash -l {0}
               run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -134,40 +134,12 @@ jobs:
                   else  # osx
                   miniconda_os=MacOSX
                   compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
-
-                  # On macOS we also need the conda libx11 libraries used to build xspec
-                  # We also need to pin down ncurses, for now only on macos.
-                  xorg="xorg-libx11"
                   fi
-
-                  # Get the version in the __version__ environment variable
-                  #python ci/set_minor_version.py --patch $TRAVIS_BUILD_NUMBER --version_file threeML/version.py
-
-                  #export PKG_VERSION=$(cd threeML && python -c "import version;print(version.__version__)")
-
-                  export PKG_VERSION=$(python -c "import versioneer;print(versioneer.get_version())")
 
                   echo "HOME= ${HOME}"
-                  echo "Building ${PKG_VERSION} ..."
                   echo "Python version: ${{matrix.python-version}}"
 
-                  #libgfortranver="3.0"
-                  #NUMPYVER=1.15
-                  MATPLOTLIBVER=2
-                  XSPECVER="6.25"
-                  xspec_channel=xspecmodels
-
-                  # Figure out requested dependencies
-                  if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
-                  if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
-                  if [ -n "${XSPECVER}" ];
-                  then export XSPEC="xspec-modelsonly=${XSPECVER} ${xorg}";
-                  fi
-
-
-                  PKG="pytest>=3.6 pandas>=0.23 ultranest interpolation>=2.1.5"
-
-                  mamba install ${PKG} codecov pytest-cov git ${MATPLOTLIB} ${NUMPY} ${XSPEC} astropy ${compilers} scipy astropy astromodels threeML numba reproject root emcee pymultinest ultranest flake8
+                  mamba install pytest codecov pytest-cov git matplotlib numpy astropy ${compilers} scipy astropy astromodels threeML numba reproject root flake8
                   pip install --no-binary :all: root_numpy
                   pip uninstall astromodels threeML -y
                   pip install git+https://github.com/threeml/astromodels.git

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,6 +30,7 @@ jobs:
             matrix:
                 os: ["ubuntu-latest", "macos-latest"]
                 python-version: [3.7]
+            fail-fast: false
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
@@ -103,6 +104,7 @@ jobs:
             matrix:
                 os: ["ubuntu-latest", "macos-latest"]
                 python-version: [3.7]
+            fail-fast: false
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
                   echo "HOME= ${HOME}"
                   echo "Python version: ${{matrix.python-version}}"
 
-                  mamba install pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
+                  mamba install ${compilers} pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
                   pip install --no-binary :all: root_numpy
             - name: Conda list
               shell: bash -l {0}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
                   echo "HOME= ${HOME}"
                   echo "Python version: ${{matrix.python-version}}"
 
-                  mamba install pytest codecov pytest-cov git matplotlib numpy astropy ${compilers} scipy astropy astromodels threeML numba reproject root flake8
+                  mamba install pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
                   pip install --no-binary :all: root_numpy
             - name: Conda list
               shell: bash -l {0}
@@ -139,7 +139,7 @@ jobs:
                   echo "HOME= ${HOME}"
                   echo "Python version: ${{matrix.python-version}}"
 
-                  mamba install pytest codecov pytest-cov git matplotlib numpy astropy ${compilers} scipy astropy astromodels threeML numba reproject root flake8
+                  mamba install pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
                   pip install --no-binary :all: root_numpy
                   pip uninstall astromodels threeML -y
                   pip install git+https://github.com/threeml/astromodels.git

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -46,6 +46,6 @@ dependencies:
   - tqdm
   - threeml>=2.2.1
   - future
-  - root==6
+  - root>=6.22.6
   - numba
   - reproject

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -46,6 +46,6 @@ dependencies:
   - tqdm
   - threeml>=2.2.1
   - future
-  - root>=6.22.6
+  - root==6.22.2
   - numba
   - reproject

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -46,7 +46,6 @@ dependencies:
   - tqdm
   - threeml>=2.2.1
   - future
-  - xspec-modelsonly==6.25
-  - root==6.22.2
+  - root==6
   - numba
   - reproject


### PR DESCRIPTION
Switch CI install to mamba -> much much faster now.

Test pass on linux, still issues compiling root-numpy on macos. 

I suggest merging this sooner rather than later so we have a baseline while we work on fixing the macos install. 