### PR TITLE
Revert to XCode 12.4 in MacOS CI tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,6 +114,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
+            - name: XCode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: '12.4'
+              if: runner.os == 'macOS'
             - name: Cache conda
               uses: actions/cache@v2
               with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
+            - name: XCode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: '13.0'
+              if: runner.os == 'macOS'
             - name: Cache conda
               uses: actions/cache@v2
               with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
             - name: XCode
               uses: maxim-lobanov/setup-xcode@v1
               with:
-                  xcode-version: '13.0'
+                  xcode-version: '12.4'
               if: runner.os == 'macOS'
             - name: Cache conda
               uses: actions/cache@v2


### PR DESCRIPTION
This allows `root_numpy` to be compiled.

 