### PR TITLE
Hal uproot

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
                   echo "Python version: ${{matrix.python-version}}"
 
                   mamba install ${compilers} pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
-                  pip install --no-binary :all: root_numpy
+                  
             - name: Conda list
               shell: bash -l {0}
               run: |
@@ -152,7 +152,7 @@ jobs:
                   echo "Python version: ${{matrix.python-version}}"
 
                   mamba install pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
-                  pip install --no-binary :all: root_numpy
+                  
                   pip uninstall astromodels threeML -y
                   pip install git+https://github.com/threeml/astromodels.git
                   pip install git+https://github.com/threeml/threeML.git
@@ -234,7 +234,6 @@ jobs:
                   echo "Python version: ${{matrix.python-version}}"
 
                   mamba install pytest codecov pytest-cov git astromodels threeML numba reproject root flake8
-                  mamba install -c conda-forge root_numpy
                   pip uninstall astromodels threeML -y
                   pip install git+https://github.com/threeml/astromodels.git@dev
                   pip install git+https://github.com/threeml/threeML.git@dev

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ If you don't have `mamba`,install mamba according to the [instruction](https://g
 To install hawc_hal in a conda environment, we recommend to use the following procedure: 
 
 <!-- pip install --no-binary :all: root_numpy -->
+<!-- pip install uproot awkward hist mplhep -->
 ```
 mamba create --name new_hal -c conda-forge -c threeml numpy scipy matplotlib ipython numba reproject "astromodels>=2" "threeml>=2" root
 conda activate new_hal
-pip install uproot awkward hist mplhep
 pip install git+https://github.com/threeml/hawc_hal.git
 ```
 
@@ -42,11 +42,8 @@ You can also add `hawc_hal` to an existing environment. If you have `conda` inst
 
 You also need `root` (whether installed through conda or not) and `threeML`/`astromodels` and their dependencies.
 
-HAL now has no dependencies relying on ROOT or root-numpy. But it uses `uproot` following are required for usage with HAL:
-
-```
-pip install uproot awkward hist mplhep 
-```
+HAL now has no dependencies relying on ROOT or root-numpy. Instead, it uses `uproot`. The following are installed along with HAL:
+`uproot, awkward, hist, mplhep`
 
 
 <!-- ```bash -->

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@
 
 ## Installation
 
-`hawc_hal` depends on `astromodels`, `threeML` as well as some additional packages (`numba`, `root`, `root_numpy`). 
+`hawc_hal` depends on `astromodels`, `threeML` as well as some additional packages (`numba`, `root`, `root_numpy`).
 
 If you don't have `mamba`,install mamba according to the [instruction](https://github.com/mamba-org/mamba) into the `base` environment.
 
 For install in a new conda environment, we recommend to use the following precoedure:
-
 
 ```
 mamba create --name new_hal -c conda-forge -c threeml numpy scipy matplotlib ipython numba reproject "astromodels>=2" "threeml>=2" root
@@ -28,7 +27,7 @@ pip install --upgrade git+https://github.com/threeml/astromodels.git
 pip install --upgrade git+https://github.com/threeml/threeML.git
 ```
 
-In particular, we recommend not to install the `root_numpy` binaries via conda or pip. 
+In particular, we recommend not to install the `root_numpy` binaries via conda or pip.
 
 The above will install a new python 3 environment. There seem to be version conflicts that currently prevent installing `hawc_hal` with the newer (>=2.0) versions of `threeML` and `astromodels`.
 
@@ -43,7 +42,7 @@ You also need `root` (whether installed through conda or not) and `threeML`/`ast
 Then:
 
 ```bash
-> pip install --no-binary :all: root_numpy 
+> pip install --no-binary :all: root_numpy
 > pip uninstall hawc_hal -y ; pip install git+https://github.com/threeml/hawc_hal.git
 ```
 
@@ -51,17 +50,15 @@ Then:
 
 Use the following commands to check if your installation was successful. You should be inside your conda environment for this.
 
-* To test threeML: `pytest --pyargs threeML`
-* To test astromodels: `pytest --pyargs astromodels`
-* To test HAL:  `pytest --pyargs hawc_hal`
+- To test threeML: `pytest --pyargs threeML`
+- To test astromodels: `pytest --pyargs astromodels`
+- To test HAL: `pytest --pyargs hawc_hal`
 
 If you are interested in more detailed output from the tests, learn more about pytest command line options [here](https://docs.pytest.org/en/reorganize-docs/new-docs/user/commandlineuseful.html#).
 
-
-
 ## Examples
 
-You can find a worked example relying only on publicly accessible data on the [threeML documentation](https://threeml.readthedocs.io/en/latest/notebooks/hal_example.html) 
+You can find a worked example relying only on publicly accessible data on the [threeML documentation](https://threeml.readthedocs.io/en/latest/notebooks/hal_example.html)
 (or download the [notebook](https://github.com/threeML/threeML/blob/master/docs/notebooks/hal_example.ipynb)).
 
 ### Mrk 421 analysis example
@@ -242,6 +239,8 @@ roi = HealpixConeROI(data_radius=data_radius,
                      dec=dec_mkn421)
 
 m = map_tree_factory(root_map_tree, roi)
-m.write("roi_maptree.hd5")                
+m.write("roi_maptree.hd5")
 
 ```
+
+### Radial profile examples will come soon

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then:
 
 ```bash
 > pip install --no-binary :all: root_numpy 
-> pip uninstall hawc_hal -y ; pip install git+https://github.com/torresramiro350/hawc_hal.git
+> pip uninstall hawc_hal -y ; pip install git+https://github.com/threeml/hawc_hal.git
 ```
 
 ## Check installation

--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@
 
 ## Installation
 
-`hawc_hal` depends on `astromodels`, `threeML` as well as some additional packages (`numba`, `root`, `root_numpy`).
+<!-- `hawc_hal` depends on `astromodels`, `threeML` as well as some additional packages (`numba`, `root`, `root_numpy`). -->
+
+`hawc_hal` depends on `astromodels`, `threeML` as well as some additional packages (`numba`, `uproot`).
 
 If you don't have `mamba`,install mamba according to the [instruction](https://github.com/mamba-org/mamba) into the `base` environment.
 
-For install in a new conda environment, we recommend to use the following precoedure: 
+To install hawc_hal in a conda environment, we recommend to use the following procedure: 
 
+<!-- pip install --no-binary :all: root_numpy -->
 ```
 mamba create --name new_hal -c conda-forge -c threeml numpy scipy matplotlib ipython numba reproject "astromodels>=2" "threeml>=2" root
 conda activate new_hal
-pip install --no-binary :all: root_numpy
+pip install uproot awkward hist mplhep
 pip install git+https://github.com/threeml/hawc_hal.git
 ```
 
@@ -27,7 +30,7 @@ pip install --upgrade git+https://github.com/threeml/astromodels.git
 pip install --upgrade git+https://github.com/threeml/threeML.git
 ```
 
-In particular, we recommend not to install the `root_numpy` binaries via conda or pip.
+<!-- In particular, we recommend not to install the `root_numpy` binaries via conda or pip. -->
 
 The above will install a new python 3 environment. There seem to be version conflicts that currently prevent installing `hawc_hal` with the newer (>=2.0) versions of `threeML` and `astromodels`.
 
@@ -39,12 +42,17 @@ You can also add `hawc_hal` to an existing environment. If you have `conda` inst
 
 You also need `root` (whether installed through conda or not) and `threeML`/`astromodels` and their dependencies.
 
-Then:
+HAL now has no dependencies relying on ROOT or root-numpy. But it uses `uproot` following are required for usage with HAL:
 
-```bash
-> pip install --no-binary :all: root_numpy
-> pip uninstall hawc_hal -y ; pip install git+https://github.com/threeml/hawc_hal.git
 ```
+pip install uproot awkward hist mplhep 
+```
+
+
+<!-- ```bash -->
+ <!-- > pip install --no-binary :all: root_numpy -->
+ <!-- > pip uninstall hawc_hal -y ; pip install git+https://github.com/threeml/hawc_hal.git -->
+<!-- ``` -->
 
 ## Check installation
 
@@ -155,7 +163,8 @@ jl.compute_TS("mkn421", like_df)
 # Compute goodness of fit with Monte Carlo
 gf = GoodnessOfFit(jl)
 gof, param, likes = gf.by_mc(100)
-print("Prob. of obtaining -log(like) >= observed by chance if null hypothesis is true: %.2f" % gof['HAWC'])
+# print("Prob. of obtaining -log(like) >= observed by chance if null hypothesis is true: %.2f" % gof['HAWC'])
+print(f"Prob. of obtaining -log(like) >= observed by chance if null hypothesis is true: {gof['HAWC']:.2f}")
 
 # it is a good idea to inspect the results of the simulations with some plots
 # Histogram of likelihood values

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then:
 
 ```bash
 > pip install --no-binary :all: root_numpy 
-> pip uninstall hawc_hal -y ; pip install git+https://github.com/threeml/hawc_hal.git
+> pip uninstall hawc_hal -y ; pip install git+https://github.com/torresramiro350/hawc_hal.git
 ```
 
 ## Check installation

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -1,45 +1,46 @@
 from __future__ import division
-import contextlib
-from hawc_hal.util import ra_to_longitude
-from hawc_hal.log_likelihood import log_likelihood
-from hawc_hal.psf_fast import PSFConvolutor
-from hawc_hal.healpix_handling import get_gnomonic_projection
-from hawc_hal.healpix_handling import SparseHealpix
-from hawc_hal.healpix_handling import FlatSkyToHealpixTransform
-from hawc_hal.convolved_source import (
-    ConvolvedPointSource,
-    ConvolvedExtendedSource3D,
-    ConvolvedExtendedSource2D,
-    ConvolvedSourcesContainer,
-)
-from hawc_hal.response import hawc_response_factory
-from hawc_hal.maptree.data_analysis_bin import DataAnalysisBin
-from hawc_hal.maptree.map_tree import MapTree
-from hawc_hal.maptree import map_tree_factory
-from astromodels import Parameter
-from tqdm.auto import tqdm
 
-from builtins import str
-from builtins import range
-from astropy.utils.misc import isiterable
-from past.utils import old_div
-import copy
 import collections
+import contextlib
+import copy
+from builtins import range, str
 
-import numpy as np
-import healpy as hp
 import astropy.units as u
-import matplotlib.pyplot as plt
+import healpy as hp
 import matplotlib as mpl
-from scipy.stats import poisson
-
+import matplotlib.pyplot as plt
+import numpy as np
+from astromodels import Parameter
 from astropy.convolution import Gaussian2DKernel
 from astropy.convolution import convolve_fft as convolve
 from astropy.coordinates import Angle
+from astropy.utils.misc import isiterable
+from past.utils import old_div
+from scipy.stats import poisson
+from threeML.io.logging import setup_logger
+from threeML.parallel import parallel_client
 from threeML.plugin_prototype import PluginPrototype
 from threeML.utils.statistics.gammaln import logfactorial
-from threeML.parallel import parallel_client
-from threeML.io.logging import setup_logger
+from tqdm.auto import tqdm
+
+from hawc_hal.convolved_source import (
+    ConvolvedExtendedSource2D,
+    ConvolvedExtendedSource3D,
+    ConvolvedPointSource,
+    ConvolvedSourcesContainer,
+)
+from hawc_hal.healpix_handling import (
+    FlatSkyToHealpixTransform,
+    SparseHealpix,
+    get_gnomonic_projection,
+)
+from hawc_hal.log_likelihood import log_likelihood
+from hawc_hal.maptree import map_tree_factory
+from hawc_hal.maptree.data_analysis_bin import DataAnalysisBin
+from hawc_hal.maptree.map_tree import MapTree
+from hawc_hal.psf_fast import PSFConvolutor
+from hawc_hal.response import hawc_response_factory
+from hawc_hal.util import ra_to_longitude
 
 log = setup_logger(__name__)
 log.propagate = False
@@ -377,323 +378,323 @@ class HAL(PluginPrototype):
 
                 self._convolved_ext_sources.append(this_convolved_ext_source)
 
-    def get_excess_background(self, ra, dec, radius):
-        """
-        Calculates area, excess (data - background) and model counts of source at different
-        distance from the source.
-        :param: radius: radial distance away from the center (degrees).
-        :returns: tuple of numpy.ndarrays for areas, excess, model, and background
-        this information is used in the get_radial_profile function.
-        """
+    # def get_excess_background(self, ra, dec, radius):
+    #     """
+    #     Calculates area, excess (data - background) and model counts of source at different
+    #     distance from the source.
+    #     :param: radius: radial distance away from the center (degrees).
+    #     :returns: tuple of numpy.ndarrays for areas, excess, model, and background
+    #     this information is used in the get_radial_profile function.
+    #     """
 
-        radius_radians = np.deg2rad(radius)
+    #     radius_radians = np.deg2rad(radius)
 
-        total_counts = np.zeros(len(self._active_planes), dtype=float)
-        background = np.zeros_like(total_counts)
-        observation = np.zeros_like(total_counts)
-        model = np.zeros_like(total_counts)
-        signal = np.zeros_like(total_counts)
-        area = np.zeros_like(total_counts)
+    #     total_counts = np.zeros(len(self._active_planes), dtype=float)
+    #     background = np.zeros_like(total_counts)
+    #     observation = np.zeros_like(total_counts)
+    #     model = np.zeros_like(total_counts)
+    #     signal = np.zeros_like(total_counts)
+    #     area = np.zeros_like(total_counts)
 
-        n_point_sources = self._likelihood_model.get_number_of_point_sources()
-        n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
+    #     n_point_sources = self._likelihood_model.get_number_of_point_sources()
+    #     n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
-        longitude = ra_to_longitude(ra)
-        latitude = dec
-        center = hp.ang2vec(longitude, latitude, lonlat=True)
+    #     longitude = ra_to_longitude(ra)
+    #     latitude = dec
+    #     center = hp.ang2vec(longitude, latitude, lonlat=True)
 
-        for i, energy_id in enumerate(self._active_planes):
-            data_analysis_bin = self._maptree[energy_id]
-            this_nside = data_analysis_bin.observation_map.nside
+    #     for i, energy_id in enumerate(self._active_planes):
+    #         data_analysis_bin = self._maptree[energy_id]
+    #         this_nside = data_analysis_bin.observation_map.nside
 
-            pixels_at_radius = hp.query_disc(
-                this_nside,
-                center,
-                radius_radians,
-                inclusive=False,
-            )
+    #         pixels_at_radius = hp.query_disc(
+    #             this_nside,
+    #             center,
+    #             radius_radians,
+    #             inclusive=False,
+    #         )
 
-            # calculate the areas per bin by the product
-            # of pixel area by the number of pixels at each radial bin
-            area[i] = hp.nside2pixarea(this_nside) * pixels_at_radius.shape[0]
+    #         # calculate the areas per bin by the product
+    #         # of pixel area by the number of pixels at each radial bin
+    #         area[i] = hp.nside2pixarea(this_nside) * pixels_at_radius.shape[0]
 
-            # NOTE: select active pixels according to each radial bin
-            bin_active_pixel_indexes = np.intersect1d(
-                self._active_pixels[energy_id], pixels_at_radius, return_indices=True
-            )[1]
+    #         # NOTE: select active pixels according to each radial bin
+    #         bin_active_pixel_indexes = np.intersect1d(
+    #             self._active_pixels[energy_id], pixels_at_radius, return_indices=True
+    #         )[1]
 
-            # obtain the excess, background, and expected excess at each radial bin
-            data = data_analysis_bin.observation_map.as_partial()
-            bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_model_map(
-                energy_id, n_point_sources, n_ext_sources
-            ).as_partial()
+    #         # obtain the excess, background, and expected excess at each radial bin
+    #         data = data_analysis_bin.observation_map.as_partial()
+    #         bkg = data_analysis_bin.background_map.as_partial()
+    #         mdl = self._get_model_map(
+    #             energy_id, n_point_sources, n_ext_sources
+    #         ).as_partial()
 
-            bin_data = np.array([data[i] for i in bin_active_pixel_indexes])
-            bin_bkg = np.array([bkg[i] for i in bin_active_pixel_indexes])
-            bin_model = np.array([mdl[i] for i in bin_active_pixel_indexes])
+    #         bin_data = np.array([data[i] for i in bin_active_pixel_indexes])
+    #         bin_bkg = np.array([bkg[i] for i in bin_active_pixel_indexes])
+    #         bin_model = np.array([mdl[i] for i in bin_active_pixel_indexes])
 
-            this_data_tot = np.sum(bin_data)
-            this_bkg_tot = np.sum(bin_bkg)
-            this_model_tot = np.sum(bin_model)
+    #         this_data_tot = np.sum(bin_data)
+    #         this_bkg_tot = np.sum(bin_bkg)
+    #         this_model_tot = np.sum(bin_model)
 
-            background[i] = this_bkg_tot
-            observation[i] = this_data_tot
-            model[i] = this_model_tot
-            signal[i] = this_data_tot - this_bkg_tot
+    #         background[i] = this_bkg_tot
+    #         observation[i] = this_data_tot
+    #         model[i] = this_model_tot
+    #         signal[i] = this_data_tot - this_bkg_tot
 
-        return area, signal, model, background
+    #     return area, signal, model, background
 
-    def get_radial_profile(
-        self,
-        ra,
-        dec,
-        active_planes=None,
-        max_radius=3.0,
-        n_radial_bins=30,
-        model_to_subtract=None,
-        subtract_model_from_model=False,
-    ):
-        """Calculates radial profiles for a source in units of excess counts per steradian
+    # def get_radial_profile(
+    #     self,
+    #     ra,
+    #     dec,
+    #     active_planes=None,
+    #     max_radius=3.0,
+    #     n_radial_bins=30,
+    #     model_to_subtract=None,
+    #     subtract_model_from_model=False,
+    # ):
+    #     """Calculates radial profiles for a source in units of excess counts per steradian
 
-        Args:
-            ra (float): RA of sky location of source
-            dec (float): Declincation of origin of radial profile
-            active_planes (np.ndarray, optional): List of active planes over which
-            to average. Defaults to None.
-            max_radius (float, optional): Radius up to which evaluate the radial
-            profile. Defaults to 3.0.
-            n_radial_bins (int, optional): Number of radiaul bins to use for
-            the profile. Defaults to 30.
-            model_to_subtract (astromodels.model, optional): Another model to subtract from
-            the data excess. Defaults to None.
-            subtract_model_from_model (bool, optional): If True, and model_to_subtract is not None,
-            subtract model from model too. Defaults to False.
+    #     Args:
+    #         ra (float): RA of sky location of source
+    #         dec (float): Declincation of origin of radial profile
+    #         active_planes (np.ndarray, optional): List of active planes over which
+    #         to average. Defaults to None.
+    #         max_radius (float, optional): Radius up to which evaluate the radial
+    #         profile. Defaults to 3.0.
+    #         n_radial_bins (int, optional): Number of radiaul bins to use for
+    #         the profile. Defaults to 30.
+    #         model_to_subtract (astromodels.model, optional): Another model to subtract from
+    #         the data excess. Defaults to None.
+    #         subtract_model_from_model (bool, optional): If True, and model_to_subtract is not None,
+    #         subtract model from model too. Defaults to False.
 
-        Returns:
-            tuple(np.ndarray): returns list of radial distances, excess expected counts,
-            excess counts, counts uncertainty, and list of sorted active_planes
-        """
-        # default is to use all active bins
-        if active_planes is None:
-            active_planes = self._active_planes
+    #     Returns:
+    #         tuple(np.ndarray): returns list of radial distances, excess expected counts,
+    #         excess counts, counts uncertainty, and list of sorted active_planes
+    #     """
+    #     # default is to use all active bins
+    #     if active_planes is None:
+    #         active_planes = self._active_planes
 
-        # Make sure we use bins with data
-        good_planes = [plane_id in active_planes for plane_id in self._active_planes]
-        plane_ids = set(active_planes) & set(self._active_planes)
+    #     # Make sure we use bins with data
+    #     good_planes = [plane_id in active_planes for plane_id in self._active_planes]
+    #     plane_ids = set(active_planes) & set(self._active_planes)
 
-        offset = 0.5
-        delta_r = 1.0 * max_radius / n_radial_bins
-        radii = np.array([delta_r * (r + offset) for r in range(n_radial_bins)])
-        # radii = np.linspace(0.5 * delta_r, max_radius, n_radial_bins, endpoint=False)
+    #     offset = 0.5
+    #     delta_r = 1.0 * max_radius / n_radial_bins
+    #     radii = np.array([delta_r * (r + offset) for r in range(n_radial_bins)])
+    #     # radii = np.linspace(0.5 * delta_r, max_radius, n_radial_bins, endpoint=False)
 
-        # Get area of all pixels in a given circle
-        # The area of each ring is then given by the difference between two
-        # subsequent circe areas.
-        area = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[0]
-                for r in radii
-            ]
-        )
+    #     # Get area of all pixels in a given circle
+    #     # The area of each ring is then given by the difference between two
+    #     # subsequent circe areas.
+    #     area = np.array(
+    #         [
+    #             self.get_excess_background(ra, dec, r + offset * delta_r)[0]
+    #             for r in radii
+    #         ]
+    #     )
 
-        temp = area[1:] - area[:-1]
-        area[1:] = temp
+    #     temp = area[1:] - area[:-1]
+    #     area[1:] = temp
 
-        # model
-        # convert 'top hat' excess into 'ring' excesses.
-        model = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[2]
-                for r in radii
-            ]
-        )
+    #     # model
+    #     # convert 'top hat' excess into 'ring' excesses.
+    #     model = np.array(
+    #         [
+    #             self.get_excess_background(ra, dec, r + offset * delta_r)[2]
+    #             for r in radii
+    #         ]
+    #     )
 
-        temp = model[1:] - model[:-1]
-        model[1:] = temp
+    #     temp = model[1:] - model[:-1]
+    #     model[1:] = temp
 
-        # signals
-        signal = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[1]
-                for r in radii
-            ]
-        )
+    #     # signals
+    #     signal = np.array(
+    #         [
+    #             self.get_excess_background(ra, dec, r + offset * delta_r)[1]
+    #             for r in radii
+    #         ]
+    #     )
 
-        temp = signal[1:] - signal[:-1]
-        signal[1:] = temp
+    #     temp = signal[1:] - signal[:-1]
+    #     signal[1:] = temp
 
-        # backgrounds
-        bkg = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[3]
-                for r in radii
-            ]
-        )
+    #     # backgrounds
+    #     bkg = np.array(
+    #         [
+    #             self.get_excess_background(ra, dec, r + offset * delta_r)[3]
+    #             for r in radii
+    #         ]
+    #     )
 
-        temp = bkg[1:] - bkg[:-1]
-        bkg[1:] = temp
+    #     temp = bkg[1:] - bkg[:-1]
+    #     bkg[1:] = temp
 
-        counts = signal + bkg
+    #     counts = signal + bkg
 
-        if model_to_subtract is not None:
-            this_model = copy.deepcopy(self._likelihood_model)
-            self.set_model(model_to_subtract)
+    #     if model_to_subtract is not None:
+    #         this_model = copy.deepcopy(self._likelihood_model)
+    #         self.set_model(model_to_subtract)
 
-            model_subtract = np.array(
-                [
-                    self.get_excess_background(ra, dec, r + offset * delta_r)[2]
-                    for r in radii
-                ]
-            )
+    #         model_subtract = np.array(
+    #             [
+    #                 self.get_excess_background(ra, dec, r + offset * delta_r)[2]
+    #                 for r in radii
+    #             ]
+    #         )
 
-            temp = model_subtract[1:] - model_subtract[:-1]
-            model_subtract[1:] = temp
+    #         temp = model_subtract[1:] - model_subtract[:-1]
+    #         model_subtract[1:] = temp
 
-            signal -= model_subtract
+    #         signal -= model_subtract
 
-            if subtract_model_from_model:
-                model -= model_subtract
+    #         if subtract_model_from_model:
+    #             model -= model_subtract
 
-            self.set_model(this_model)
+    #         self.set_model(this_model)
 
-        # NOTE: weights are calculated as expected number of gamma-rays/number of background counts.
-        # here, use max_radius to evaluate the number of gamma-rays/bkg counts.
-        # The weights do not depend on the radius, but fill a matrix anyway so
-        # there's no confusion when multiplying them to the data later.
-        # Weight is normalized (sum of weights over the bins = 1).
+    #     # NOTE: weights are calculated as expected number of gamma-rays/number of background counts.
+    #     # here, use max_radius to evaluate the number of gamma-rays/bkg counts.
+    #     # The weights do not depend on the radius, but fill a matrix anyway so
+    #     # there's no confusion when multiplying them to the data later.
+    #     # Weight is normalized (sum of weights over the bins = 1).
 
-        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[
-            good_planes
-        ]
+    #     total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[
+    #         good_planes
+    #     ]
 
-        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
-            good_planes
-        ]
+    #     total_model = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
+    #         good_planes
+    #     ]
 
-        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
-            good_planes
-        ]
+    #     total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
+    #         good_planes
+    #     ]
 
-        w = np.divide(total_model, total_bkg)
-        weight = np.array([w / np.sum(w) for r in radii])
+    #     w = np.divide(total_model, total_bkg)
+    #     weight = np.array([w / np.sum(w) for r in radii])
 
-        # restrict profiles to the user-specified analysis bins
-        area = area[:, good_planes]
-        signal = signal[:, good_planes]
-        model = model[:, good_planes]
-        counts = counts[:, good_planes]
-        bkg = bkg[:, good_planes]
+    #     # restrict profiles to the user-specified analysis bins
+    #     area = area[:, good_planes]
+    #     signal = signal[:, good_planes]
+    #     model = model[:, good_planes]
+    #     counts = counts[:, good_planes]
+    #     bkg = bkg[:, good_planes]
 
-        # average over the analysis bins
-        excess_data = np.average(signal / area, weights=weight, axis=1)
-        excess_error = np.sqrt(np.sum(counts * weight * weight / (area * area), axis=1))
-        excess_model = np.average(model / area, weights=weight, axis=1)
+    #     # average over the analysis bins
+    #     excess_data = np.average(signal / area, weights=weight, axis=1)
+    #     excess_error = np.sqrt(np.sum(counts * weight * weight / (area * area), axis=1))
+    #     excess_model = np.average(model / area, weights=weight, axis=1)
 
-        return radii, excess_model, excess_data, excess_error, sorted(plane_ids)
+    #     return radii, excess_model, excess_data, excess_error, sorted(plane_ids)
 
-    def plot_radial_profile(
-        self,
-        ra,
-        dec,
-        active_planes=None,
-        max_radius=3.0,
-        n_radial_bins=30,
-        model_to_subtract=None,
-        subtract_model_from_model=False,
-    ):
-        """Plots radial profiles of data-background & model
+    # def plot_radial_profile(
+    #     self,
+    #     ra,
+    #     dec,
+    #     active_planes=None,
+    #     max_radius=3.0,
+    #     n_radial_bins=30,
+    #     model_to_subtract=None,
+    #     subtract_model_from_model=False,
+    # ):
+    #     """Plots radial profiles of data-background & model
 
-        Args:
-            ra (float): RA of origin of radial profile
-            dec (float): Declination of origin of radial profile.
-            active_planes (np.ndarray, optional): List of analysis bins over which to average.
-            Defaults to None.
-            max_radius (float, optional): Radius up to which the radial profile is evaluate;
-            also used as the radius for the disk to calculate the gamma/hadron
-            weights. Defaults to 3.0.
-            n_radial_bins (int, optional): number of radial bins used for ring
-            calculation. Defaults to 30.
-            model_to_subtract (astromodels.model, optional): Another model that is to be subtracted
-            from the data excess. Defaults to None.
-            subtract_model_from_model (bool, optional): If True and model_to_subtract is not None,
-            subtract from model too. Defaults to False.
+    #     Args:
+    #         ra (float): RA of origin of radial profile
+    #         dec (float): Declination of origin of radial profile.
+    #         active_planes (np.ndarray, optional): List of analysis bins over which to average.
+    #         Defaults to None.
+    #         max_radius (float, optional): Radius up to which the radial profile is evaluate;
+    #         also used as the radius for the disk to calculate the gamma/hadron
+    #         weights. Defaults to 3.0.
+    #         n_radial_bins (int, optional): number of radial bins used for ring
+    #         calculation. Defaults to 30.
+    #         model_to_subtract (astromodels.model, optional): Another model that is to be subtracted
+    #         from the data excess. Defaults to None.
+    #         subtract_model_from_model (bool, optional): If True and model_to_subtract is not None,
+    #         subtract from model too. Defaults to False.
 
-        Returns:
-            matplotlib.pyplot.Figure: plot of data - background & model radial profile for source
-        """
+    #     Returns:
+    #         matplotlib.pyplot.Figure: plot of data - background & model radial profile for source
+    #     """
 
-        (
-            radii,
-            excess_model,
-            excess_data,
-            excess_error,
-            plane_ids,
-        ) = self.get_radial_profile(
-            ra,
-            dec,
-            active_planes,
-            max_radius,
-            n_radial_bins,
-            model_to_subtract,
-            subtract_model_from_model,
-        )
+    #     (
+    #         radii,
+    #         excess_model,
+    #         excess_data,
+    #         excess_error,
+    #         plane_ids,
+    #     ) = self.get_radial_profile(
+    #         ra,
+    #         dec,
+    #         active_planes,
+    #         max_radius,
+    #         n_radial_bins,
+    #         model_to_subtract,
+    #         subtract_model_from_model,
+    #     )
 
-        fig, ax = plt.subplots(figsize=(10, 8))
+    #     fig, ax = plt.subplots(figsize=(10, 8))
 
-        plt.errorbar(
-            radii,
-            excess_data,
-            yerr=excess_error,
-            capsize=0,
-            color="black",
-            label="Excess (data-bkg)",
-            fmt=".",
-        )
+    #     plt.errorbar(
+    #         radii,
+    #         excess_data,
+    #         yerr=excess_error,
+    #         capsize=0,
+    #         color="black",
+    #         label="Excess (data-bkg)",
+    #         fmt=".",
+    #     )
 
-        plt.plot(radii, excess_model, color="red", label="Model")
+    #     plt.plot(radii, excess_model, color="red", label="Model")
 
-        plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1)
-        plt.axhline(0, color="deepskyblue", linestyle="--")
+    #     plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1)
+    #     plt.axhline(0, color="deepskyblue", linestyle="--")
 
-        x_limits = [0, max_radius]
-        plt.xlim(x_limits)
-        plt.xticks(fontsize=18)
-        plt.yticks(fontsize=18)
+    #     x_limits = [0, max_radius]
+    #     plt.xlim(x_limits)
+    #     plt.xticks(fontsize=18)
+    #     plt.yticks(fontsize=18)
 
-        plt.ylabel(r"Apparent Radial Excess [sr$^{-1}$]", fontsize=18)
-        plt.xlabel(
-            f"Distance from source at ({ra:0.2f} $^{{\circ}}$, {dec:0.2f} $^{{\circ}}$)",
-            fontsize=18,
-        )
+    #     plt.ylabel(r"Apparent Radial Excess [sr$^{-1}$]", fontsize=18)
+    #     plt.xlabel(
+    #         f"Distance from source at ({ra:0.2f} $^{{\circ}}$, {dec:0.2f} $^{{\circ}}$)",
+    #         fontsize=18,
+    #     )
 
-        if len(plane_ids) == 1:
-            title = f"Radial Profile, bin {plane_ids[0]}"
+    #     if len(plane_ids) == 1:
+    #         title = f"Radial Profile, bin {plane_ids[0]}"
 
-        else:
-            title = "Radial Profile"
-            # tmptitle = f"Radial Profile, bins \n{plane_ids}"
-            # width = 80
-            # title = "\n".join(
-            # tmptitle[i : i + width] for i in range(0, len(tmptitle), width)
-            # )
-            # title = tmptitle
+    #     else:
+    #         title = "Radial Profile"
+    #         # tmptitle = f"Radial Profile, bins \n{plane_ids}"
+    #         # width = 80
+    #         # title = "\n".join(
+    #         # tmptitle[i : i + width] for i in range(0, len(tmptitle), width)
+    #         # )
+    #         # title = tmptitle
 
-        plt.title(title)
+    #     plt.title(title)
 
-        ax.grid(True)
+    #     ax.grid(True)
 
-        with contextlib.suppress(Exception):
-            plt.tight_layout()
-        # try:
-        #
-        # plt.tight_layout()
-        #
-        # except Exception:
-        #
-        # pass
+    #     with contextlib.suppress(Exception):
+    #         plt.tight_layout()
+    #     # try:
+    #     #
+    #     # plt.tight_layout()
+    #     #
+    #     # except Exception:
+    #     #
+    #     # pass
 
-        return fig
+    #     return fig
 
     def display_spectrum(self):
         """

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -769,7 +769,7 @@ class HAL(PluginPrototype):
     def _plot_spectrum(self, net_counts, yerr, model_only, residuals, residuals_err):
 
         fig, subs = plt.subplots(
-            2, 1, gridspec_kw={"height_ratios": [2, 1], "hspace": 0}, figsize=(12, 8)
+            2, 1, gridspec_kw={"height_ratios": [2, 1], "hspace": 0}, figsize=(14, 8)
         )
         planes = np.array(self._active_planes)
         subs[0].errorbar(

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -407,7 +407,7 @@ class HAL(PluginPrototype):
             # obtain the excess, background, and expected excess at each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_expectation(data_analysis_bin, energy_id, n_point_sources, n_ext_sources)
+            mdl = self._get_model_map(energy_id, n_point_sources, n_ext_sources).as_partial()
             
             bin_data = np.array([data[i] for i in bin_active_pixel_indexes])
             bin_bkg = np.array([bkg[i] for i in bin_active_pixel_indexes])
@@ -595,15 +595,15 @@ class HAL(PluginPrototype):
             subtract_model_from_model,
         )
         
-        font = {
-            "family":"serif",
-            "weight":"regular",
-            "size":12
-        }
+        #font = {
+        #    "family":"serif",
+        #    "weight":"regular",
+        #    "size":12
+        #}
 
-        mpl.rc("font", **font)
+        #mpl.rc("font", **font)
 
-        fig, ax = plt.subplots()
+        fig, ax = plt.subplots(figsize=(10,8))
 
         plt.errorbar(
             radii,

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -671,12 +671,13 @@ class HAL(PluginPrototype):
             title = f"Radial Profile, bin {plane_ids[0]}"
 
         else:
-            tmptitle = f"Radial Profile, bins \n{plane_ids}"
-            width = 80
-            title = "\n".join(
-                tmptitle[i : i + width] for i in range(0, len(tmptitle), width)
-            )
-            title = tmptitle
+            title = "Radial Profile"
+            # tmptitle = f"Radial Profile, bins \n{plane_ids}"
+            # width = 80
+            # title = "\n".join(
+            # tmptitle[i : i + width] for i in range(0, len(tmptitle), width)
+            # )
+            # title = tmptitle
 
         plt.title(title)
 

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -399,16 +399,21 @@ class HAL(PluginPrototype):
 
             #calculate the areas per bin by the product
             #of pixel area by the number of pixels at each radial bin
-            area[i] = hp.nside2pixarea(this_nside)*selected_pixels.size
             
             #NOTE: select active pixels according to each radial bin
             lo = np.where(selected_pixels[0] == self._active_pixels[energy_id])[0][0] 
             hi = np.where(selected_pixels[-1] == self._active_pixels[energy_id])[0][0] + 1
 
-            this_model_tot = np.sum(self._get_expectation(data_analysis_bin, energy_id, n_point_sources, n_ext_sources)[lo:hi])
-            this_data_tot = np.sum(data_analysis_bin.observation_map.as_partial()[lo:hi])
-            this_bkg_tot = np.sum(data_analysis_bin.background_map.as_partial()[lo:hi])
+            data = data_analysis_bin.observation_map.as_partial()[lo:hi]
+            bkg = data_analysis_bin.background_map.as_partial()[lo:hi]
+            mdl = self._get_expectation(data_analysis_bin, energy_id, n_point_sources, n_ext_sources)[lo:hi]
 
+            this_model_tot = np.sum(mdl)
+            this_data_tot = np.sum(data)
+            this_bkg_tot = np.sum(bkg)
+
+            #area[i] = hp.nside2pixarea(this_nside)*selected_pixels.size
+            area[i] = hp.nside2pixarea(this_nside)*mdl.size
             background[i] = this_bkg_tot
             observation[i] = this_data_tot
             model[i] = this_model_tot 
@@ -452,8 +457,8 @@ class HAL(PluginPrototype):
 
         #delta_r = old_div(1.0*max_radius, n_radial_bins)
         delta_r = 1.0*max_radius/n_radial_bins
-        #radii = np.array([delta_r*(r + 0.5) for r in range(0, n_radial_bins)])
-        radii = np.linspace(delta_r*0.5, max_radius, n_radial_bins)
+        radii = np.array([delta_r*(r + 0.5) for r in range(0, n_radial_bins + 1)])
+        #radii = np.linspace(0.02, max_radius - 0.02, n_radial_bins)
 
         #Get area of all pixels in a given circle
         #The area of each ring is then given by the difference between two

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -396,12 +396,15 @@ class HAL(PluginPrototype):
                                             inclusive=False,
             )
 
+            
             # calculate the areas per bin by the product
             # of pixel area by the number of pixels at each radial bin
+            area[i] = hp.nside2pixarea(this_nside)*pixels_at_radius.shape[0]
             
             # NOTE: select active pixels according to each radial bin
             bin_active_pixel_indexes = np.searchsorted(self._active_pixels[energy_id], pixels_at_radius)
 
+            # obtain the excess, background, and expected excess at each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
             mdl = self._get_expectation(data_analysis_bin, energy_id, n_point_sources, n_ext_sources)
@@ -415,7 +418,7 @@ class HAL(PluginPrototype):
             this_bkg_tot = np.sum(bin_bkg)
             this_model_tot = np.sum(bin_model)
 
-            area[i] = hp.nside2pixarea(this_nside)*pixels_at_radius.shape[0]
+            
             background[i] = this_bkg_tot
             observation[i] = this_data_tot
             model[i] = this_model_tot 

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -356,7 +356,7 @@ class HAL(PluginPrototype):
 
                 self._convolved_ext_sources.append(this_convolved_ext_source)
 
-    def get_excess_background(self, radius):
+    def get_excess_background(self, ra, dec, radius):
         """
         Calculates area, excess (data - background) and model counts of source at different
         distance from the source.
@@ -378,7 +378,7 @@ class HAL(PluginPrototype):
         n_point_sources = self._likelihood_model.get_number_of_point_sources()
         n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
-        ra,dec = self._roi.ra_dec_center
+        #ra,dec = self._roi.ra_dec_center
         #following the convention of Healpy as longitude for RA to be -180 to 180
         longitude = ra_to_longitude(ra)
         latitude = dec
@@ -424,6 +424,8 @@ class HAL(PluginPrototype):
 
     def get_radial_profile(
         self,
+        ra,
+        dec,
         active_planes=None,
         max_radius=3.0,
         n_radial_bins=30,
@@ -432,6 +434,8 @@ class HAL(PluginPrototype):
     ):
         """
         Calculates radial profiles of data - background & model.
+        :param ra: R.A. of origin for radial profile.
+        :param dec: Declination of origin of radial profile.
         :param active_planes: List of analysis over which to average; if None, use HAWC default (bins 1-9).
         :param: max_radius: Radius up to which the radial profile is evaluated;
         for the disk to calculate the gamma/hadron weights (Default: 3.0).
@@ -460,7 +464,7 @@ class HAL(PluginPrototype):
         #The area of each ring is then given by the difference between two
         #subsequent circe areas.
         area = np.array([
-            self.get_excess_background(r + 0.5*delta_r)[0] for r in radii ]
+            self.get_excess_background(ra, dec, r + 0.5*delta_r)[0] for r in radii ]
         )
         
         #convert to ring area
@@ -470,7 +474,7 @@ class HAL(PluginPrototype):
 
         #signals
         signal = np.array([
-            self.get_excess_background(r + 0.5*delta_r)[1] for r in radii]
+            self.get_excess_background(ra, dec, r + 0.5*delta_r)[1] for r in radii]
         )
 
         temp = signal[1:] - signal[:-1]
@@ -478,7 +482,7 @@ class HAL(PluginPrototype):
 
         #model
         model = np.array(
-            [self.get_excess_background(r+0.5*delta_r)[2] for r in radii]
+            [self.get_excess_background(ra, dec, r+0.5*delta_r)[2] for r in radii]
         )
 
         temp = model[1:] - model[:-1]
@@ -486,7 +490,7 @@ class HAL(PluginPrototype):
 
         #backgrounds
         bkg = np.array(
-            [self.get_excess_background(r+0.5*delta_r)[3] for r in radii]
+            [self.get_excess_background(ra, dec, r+0.5*delta_r)[3] for r in radii]
         )
 
         temp = bkg[1:] - bkg[:-1]
@@ -499,7 +503,7 @@ class HAL(PluginPrototype):
             self.set_model(model_to_subtract)
         
             model_subtract = np.array(
-            [self.get_excess_background(r+0.5*delta_r)[2] for r in radii]
+            [self.get_excess_background(ra, dec, r+0.5*delta_r)[2] for r in radii]
             )
             
             temp = model_subtract[1:] - model_subtract[:-1]
@@ -521,15 +525,15 @@ class HAL(PluginPrototype):
         #datas, excesses, models, backgrounds
 
         total_excess = np.array(
-            self.get_excess_background(max_radius)[1]
+            self.get_excess_background(ra, dec, max_radius)[1]
         )[good_planes]
 
         total_model = np.array(
-            self.get_excess_background(max_radius)[2]
+            self.get_excess_background(ra, dec, max_radius)[2]
         )[good_planes]
 
         total_bkg = np.array(
-            self.get_excess_background(max_radius)[3]
+            self.get_excess_background(ra, dec, max_radius)[3]
         )[good_planes]
 
         w = np.divide(total_model, total_bkg)
@@ -557,6 +561,8 @@ class HAL(PluginPrototype):
 
     def plot_radial_profile(
         self,
+        ra,
+        dec,
         active_planes=None,
         max_radius=3.0,
         n_radial_bins=30,
@@ -566,6 +572,8 @@ class HAL(PluginPrototype):
         """
         Plots radial profiles of data - background & model.
         
+        :param ra: R.A. of origin for radial profile.
+        :param dec: Declination of origin of radial profile.
         :param active_planes: List of analysis bins over which to average;
         if None, use HAWC default (bins 1-9).
         :param max_radius: Radius up to which the radial profile is evaluated; also

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -98,7 +98,7 @@ def from_root_file(
     if roi is None:
         log.warning("You have set roi=None, so you are reading the entire sky")
 
-    # Main motivation: root_numpy has been deprecated and it its no longer supported
+    # Note: Main motivation: root_numpy has been deprecated and it its no longer supported
     # uproot seems like an alternative to this challenge
     # uproot an I/O framework for reading information from ROOT files, so it
     # NOTE: no direct way of reading Nside and HEALPix scheme from ROOT file
@@ -126,8 +126,8 @@ def from_root_file(
         n_durations = np.divide(map_infile["BinInfo"]["totalDuration"].array(), 24.0)
 
         # number of transits is obtained from first bin in maptree
-        n_transits = n_durations[0]
-        n_bins = data_bins_labels.shape[0]
+        n_transits: float = n_durations[0]
+        n_bins: int = data_bins_labels.shape[0]
 
         # so far, a value of Nside of 1024  (perhaps will change) and a RING HEALPix
         assert (

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -158,12 +158,22 @@ def from_root_file(
             if roi is not None:
                 # Note: first attempt at reading only a partial map specified by the
                 # active pixel ids.
-                counts = map_infile[f"nHit{name}"]["data"]["count"].array(library="np")[
-                    healpix_map_active > 0
-                ]
-                bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array(library="np")[
-                    healpix_map_active > 0
-                ]
+                try:
+                    counts = map_infile[f"nHit{name}"]["data"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
+                    bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array(library="np")[
+                        healpix_map_active > 0
+                    ]
+                except uproot.KeyInFileError:
+                    # Sometimes, names of bins carry an extra zero
+                    counts = map_infile[f"nHit{name:02}"]["data"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
+                    bkg = map_infile[f"nHit{name:02}"]["bkg"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
+
                 counts_hpx = SparseHealpix(counts, active_pixels, nside_cnt)
                 bkg_hpx = SparseHealpix(bkg, active_pixels, nside_cnt)
 

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -122,10 +122,9 @@ def from_root_file(
 
                 raise ValueError("Maptree has no Branch: 'id' or 'name'") from exc
 
-        n_durations = np.divide(map_infile["BinInfo"]["totalDuration"].array(), 24.0)
-
-        # number of transits is obtained from first bin in maptree
+        # HACK:workaround method of getting the Nside from maptree
         bin_name = data_bins_labels[0]
+
         try:
             npix_cnt = (
                 map_infile[f"nHit{bin_name}"]["data"]["count"].array().to_numpy().size
@@ -142,6 +141,8 @@ def from_root_file(
                 map_infile[f"nHit0{bin_name}"]["data"]["count"].array().to_numpy().size
             )
 
+        # number of transits is obtained from first bin in maptree
+        n_durations = np.divide(map_infile["BinInfo"]["totalDuration"].array(), 24.0)
         n_transits: float = n_durations[0]
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
@@ -212,14 +213,14 @@ def from_root_file(
             else:
 
                 try:
-                    
+
                     counts = (
                         map_infile[f"nHit{name}"]["data"]["count"].array().to_numpy()
                     )
                     bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array().to_numpy()
 
                 except uproot.KeyInFileError:
-                    
+
                     # Sometimes, names of bins carry an extra zero
                     counts = (
                         map_infile[f"nHit0{name}"]["data"]["count"].array().to_numpy()

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -338,7 +338,6 @@ def from_root_file(
             #             )
             #
             # data_analysis_bins[name] = this_data_analysis_bin
-
     return data_analysis_bins
 
 

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -78,7 +78,7 @@ def from_root_file(
         dict: returns a dictionary with names of analysis bins found in Maptree
     """
 
-    from ..root_handler import open_ROOT_file, root_numpy, tree_to_ndarray
+    # from ..root_handler import open_ROOT_file, root_numpy, tree_to_ndarray
 
     map_tree_file = sanitize_filename(map_tree_file)
 

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -167,10 +167,10 @@ def from_root_file(
                     ]
                 except uproot.KeyInFileError:
                     # Sometimes, names of bins carry an extra zero
-                    counts = map_infile[f"nHit{name:02}"]["data"]["count"].array(
+                    counts = map_infile[f"nHit0{name}"]["data"]["count"].array(
                         library="np"
                     )[healpix_map_active > 0]
-                    bkg = map_infile[f"nHit{name:02}"]["bkg"]["count"].array(
+                    bkg = map_infile[f"nHit0{name}"]["bkg"]["count"].array(
                         library="np"
                     )[healpix_map_active > 0]
 
@@ -189,8 +189,21 @@ def from_root_file(
             # Read the whole sky
             else:
 
-                counts = map_infile[f"nHit{name}"]["data"]["count"].array(library="np")
-                bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array(library="np")
+                try:
+                    counts = map_infile[f"nHit{name}"]["data"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
+                    bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array(library="np")[
+                        healpix_map_active > 0
+                    ]
+                except uproot.KeyInFileError:
+                    # Sometimes, names of bins carry an extra zero
+                    counts = map_infile[f"nHit0{name}"]["data"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
+                    bkg = map_infile[f"nHit0{name}"]["bkg"]["count"].array(
+                        library="np"
+                    )[healpix_map_active > 0]
 
                 this_data_analysis_bin = DataAnalysisBin(
                     name,

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -130,7 +130,7 @@ def from_root_file(
                 map_infile[f"nHit{bin_name}"]["data"]["count"].array().to_numpy().size
             )
             npix_bkg = (
-                map_infile[f"nHit{bin_name}"]["data"]["count"].array().to_numpy().size
+                map_infile[f"nHit{bin_name}"]["bkg"]["count"].array().to_numpy().size
             )
 
         except uproot.KeyInFileError:
@@ -138,12 +138,17 @@ def from_root_file(
                 map_infile[f"nHit0{bin_name}"]["data"]["count"].array().to_numpy().size
             )
             npix_bkg = (
-                map_infile[f"nHit0{bin_name}"]["data"]["count"].array().to_numpy().size
+                map_infile[f"nHit0{bin_name}"]["bkg"]["count"].array().to_numpy().size
             )
 
-        # number of transits is obtained from first bin in maptree
+        # The map-maker underestimate the livetime of bins with low statistic by
+        # removing time intervals with zero events. Therefore, the best estimate
+        # of the livetime is the maximum of n_transits, which normally
+        # happen in the bins with high statistic
+
         n_durations = np.divide(map_infile["BinInfo"]["totalDuration"].array(), 24.0)
-        n_transits: float = n_durations[0]
+        n_transits: float = max(n_durations)
+
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
         nside_bkg: int = hp.pixelfunc.npix2nside(npix_bkg)

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -228,28 +228,28 @@ class PSFWrapper(object):
 
         return new_instance
 
-    @classmethod
-    def from_TF1(cls, tf1_instance):
-
-        # Annoyingly, some PSFs for some Dec bins (at large Zenith angles) have
-        # zero or negative integrals, i.e., they are useless. Return an unusable PSF
-        # object in that case
-        if tf1_instance.Integral(0, _INTEGRAL_OUTER_RADIUS) <= 0.0:
-
-            return InvalidPSF()
-
-        # Make interpolation
-        xs = np.logspace(-3, np.log10(_INTEGRAL_OUTER_RADIUS), 500)
-        ys = np.array([tf1_instance.Eval(x) for x in xs], float)
-
-        assert np.all(np.isfinite(xs))
-        assert np.all(np.isfinite(ys))
-
-        instance = cls(xs, ys)
-
-        instance._tf1 = tf1_instance.Clone()
-
-        return instance
+    # @classmethod
+    # def from_TF1(cls, tf1_instance):
+    #
+    #     # Annoyingly, some PSFs for some Dec bins (at large Zenith angles) have
+    #     # zero or negative integrals, i.e., they are useless. Return an unusable PSF
+    #     # object in that case
+    #     if tf1_instance.Integral(0, _INTEGRAL_OUTER_RADIUS) <= 0.0:
+    #
+    #         return InvalidPSF()
+    #
+    #     # Make interpolation
+    #     xs = np.logspace(-3, np.log10(_INTEGRAL_OUTER_RADIUS), 500)
+    #     ys = np.array([tf1_instance.Eval(x) for x in xs], float)
+    #
+    #     assert np.all(np.isfinite(xs))
+    #     assert np.all(np.isfinite(ys))
+    #
+    #     instance = cls(xs, ys)
+    #
+    #     instance._tf1 = tf1_instance.Clone()
+    #
+    #     return instance
 
     def integral(self, a, b):
 

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -188,7 +188,8 @@ class PSFWrapper(object):
         # is simply an I/O framework meant to read the information from TTree objects,
         # with no ROOT functionality
         def psf_function(ang_dist: float):
-            """returns expected counts provided with angular distances as input
+            """
+            Returns expected counts provided with angular distances as input
 
             Args:
                 ang_dist (float): angular distances
@@ -210,7 +211,9 @@ class PSFWrapper(object):
                 )
             )
 
-        # uproot has no methods to act on histograms. Therefore, using scipy for integral
+        # uproot has no methods to act on histograms. Therefore, using scipy
+        # to compute integral.
+        # integral returns a tuple with integral result, and absolute error
         if scipy.integrate.quad(psf_function, 0, _INTEGRAL_OUTER_RADIUS)[0] <= 0.0:
             return InvalidPSF()
 

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -2,7 +2,9 @@ from __future__ import division
 from builtins import zip
 from builtins import object
 from past.utils import old_div
+import copy
 import numpy as np
+import scipy.integrate
 import scipy.interpolate
 import scipy.optimize
 import pandas as pd
@@ -16,19 +18,20 @@ class InvalidPSFError(ValueError):
 
 
 class PSFWrapper(object):
-
     def __init__(self, xs, ys, brightness_interp_x=None, brightness_interp_y=None):
 
         self._xs = xs
         self._ys = ys
 
-        self._psf_interpolated = scipy.interpolate.InterpolatedUnivariateSpline(xs, ys, k=2,
-                                                                                ext='raise',
-                                                                                check_finite=True)
+        self._psf_interpolated = scipy.interpolate.InterpolatedUnivariateSpline(
+            xs, ys, k=2, ext="raise", check_finite=True
+        )
 
         # Memorize the total integral (will use it for normalization)
 
-        self._total_integral = self._psf_interpolated.integral(self._xs[0], _INTEGRAL_OUTER_RADIUS)
+        self._total_integral = self._psf_interpolated.integral(
+            self._xs[0], _INTEGRAL_OUTER_RADIUS
+        )
 
         # Now compute the truncation radius, which is a very conservative measurement
         # of the size of the PSF
@@ -45,16 +48,21 @@ class PSFWrapper(object):
 
         if brightness_interp_x is None:
 
-            brightness_interp_x, brightness_interp_y = self._prepare_brightness_interpolation_points()
+            (
+                brightness_interp_x,
+                brightness_interp_y,
+            ) = self._prepare_brightness_interpolation_points()
 
         self._brightness_interp_x = brightness_interp_x
         self._brightness_interp_y = brightness_interp_y
 
-        self._brightness_interpolation = scipy.interpolate.InterpolatedUnivariateSpline(brightness_interp_x,
-                                                                                        brightness_interp_y,
-                                                                                        k=2,
-                                                                                        ext='extrapolate',
-                                                                                        check_finite=True)
+        self._brightness_interpolation = scipy.interpolate.InterpolatedUnivariateSpline(
+            brightness_interp_x,
+            brightness_interp_y,
+            k=2,
+            ext="extrapolate",
+            check_finite=True,
+        )
 
     def _prepare_brightness_interpolation_points(self):
 
@@ -62,7 +70,16 @@ class PSFWrapper(object):
         interp_x = (self._xs[1:] + self._xs[:-1]) / 2.0
 
         # Compute the density
-        interp_y = np.array([(self.integral(a_b[0], a_b[1]) / (np.pi * (a_b[1] ** 2 - a_b[0] ** 2)) / self._total_integral) for a_b in zip(self._xs[:-1], self._xs[1:])])
+        interp_y = np.array(
+            [
+                (
+                    self.integral(a_b[0], a_b[1])
+                    / (np.pi * (a_b[1] ** 2 - a_b[0] ** 2))
+                    / self._total_integral
+                )
+                for a_b in zip(self._xs[:-1], self._xs[1:])
+            ]
+        )
 
         # Add zero at r = _INTEGRAL_OUTER_RADIUS so that the extrapolated values will be correct
         interp_x = np.append(interp_x, [_INTEGRAL_OUTER_RADIUS])
@@ -74,7 +91,9 @@ class PSFWrapper(object):
 
         f = lambda r: fraction - old_div(self.integral(1e-4, r), self._total_integral)
 
-        radius, status = scipy.optimize.brentq(f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output = True)
+        radius, status = scipy.optimize.brentq(
+            f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output=True
+        )
 
         assert status.converged, "Brentq did not converged"
 
@@ -115,15 +134,20 @@ class PSFWrapper(object):
         new_ys = w1 * self.ys + w2 * other_psf.ys
 
         # Also weight the brightness interpolation points
-        new_br_interp_y = w1 * self._brightness_interp_y + w2 * other_psf._brightness_interp_y
+        new_br_interp_y = (
+            w1 * self._brightness_interp_y + w2 * other_psf._brightness_interp_y
+        )
 
-        return PSFWrapper(self.xs, new_ys,
-                          brightness_interp_x=self._brightness_interp_x,
-                          brightness_interp_y=new_br_interp_y)
+        return PSFWrapper(
+            self.xs,
+            new_ys,
+            brightness_interp_x=self._brightness_interp_x,
+            brightness_interp_y=new_br_interp_y,
+        )
 
     def to_pandas(self):
 
-        items = (('xs', self._xs), ('ys', self._ys))
+        items = (("xs", self._xs), ("ys", self._ys))
 
         return pd.DataFrame.from_dict(dict(items))
 
@@ -131,13 +155,15 @@ class PSFWrapper(object):
     def from_pandas(cls, df):
 
         # Check for an invalid PSF
-        xs = df.loc[:, 'xs'].values
-        ys = df.loc[:, 'ys'].values
+        xs = df.loc[:, "xs"].values
+        ys = df.loc[:, "ys"].values
 
         if len(xs) == 0:
 
             # Should never happen
-            assert len(ys) == 0, "Corrupted response file? A PSF has 0 xs values but more than 0 ys values"
+            assert (
+                len(ys) == 0
+            ), "Corrupted response file? A PSF has 0 xs values but more than 0 ys values"
 
             # An invalid PSF
             return InvalidPSF()
@@ -145,6 +171,39 @@ class PSFWrapper(object):
         else:
 
             return cls(xs, ys)
+
+    @classmethod
+    def from_uproot_eval(cls, fun_parameters):
+
+        # The analytical form of PSF needs to be declared here given that uproot
+        # is simply an I/O framework meant to read the information from TTree objects,
+        # with no ROOT functionality
+        def psf_function(x):
+            return fun_parameters[0] * (
+                x
+                * (
+                    (fun_parameters[1] * np.exp(-(x * ((x / 2) / fun_parameters[2]))))
+                    + (
+                        (1 - fun_parameters[1])
+                        * np.exp(-(x * ((x / 2) / fun_parameters[3])))
+                    )
+                )
+            )
+
+        # uproot has no methods to act on histograms. Therefore, I simply used scipy integral
+        if scipy.integrate.quad(psf_function, 0, _INTEGRAL_OUTER_RADIUS)[0] <= 0.0:
+            return InvalidPSF()
+
+        xs = np.logspace(-3, np.log10(_INTEGRAL_OUTER_RADIUS), 500)
+        ys = np.array([psf_function(x) for x in xs])
+
+        assert np.all(np.isfinite(xs))
+        assert np.all(np.isfinite(ys))
+
+        instance = cls(xs, ys)
+        new_instance = copy.deepcopy(instance)
+
+        return new_instance
 
     @classmethod
     def from_TF1(cls, tf1_instance):
@@ -199,7 +258,7 @@ class InvalidPSF(object):
     # This allow the Invalid PSF to be saved in the HDF file
     def to_pandas(self):
 
-        items = (('xs', []), ('ys', []))
+        items = (("xs", []), ("ys", []))
 
         return pd.DataFrame.from_dict(dict(items))
 

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -208,23 +208,23 @@ class HAWCResponse(object):
             # There is no way to evaluate the loglogspectrum function with uproot, so the
             # parameters are passed for evaluation in response_bin.py
             log_log_params = response_file['LogLogSpectrum'].member('fParams')
-            dec_bins_lower_edge = response_file['DecBins']['lowerEdge'].array(library='np')
-            dec_bins_upper_edge = response_file['DecBins']['upperEdge'].array(library='np')
-            dec_bins_center = response_file['DecBins']['simdec'].array(library='np')
+            dec_bins_lower_edge = response_file['DecBins']['lowerEdge'].array().to_numpy()
+            dec_bins_upper_edge = response_file['DecBins']['upperEdge'].array().to_numpy()
+            dec_bins_center = response_file['DecBins']['simdec'].array().to_numpy()
 
             dec_bins = list(zip(dec_bins_lower_edge, dec_bins_center, dec_bins_upper_edge))
 
             try:
 
-                response_bin_ids = response_file["AnalysisBins"]["name"].array(library='np')
+                response_bin_ids = response_file["AnalysisBins"]["name"].array().to_numpy()
 
-            except ValueError:
+            except uproot.KeyInFileError:
 
                 try:
 
-                    response_bin_ids = response_file['AnalysisBins']['id'].array(library='np')
+                    response_bin_ids = response_file["AnalysisBins"]["id"].array().to_numpy()
 
-                except ValueError:
+                except uproot.KeyInFileError:
 
                     log.warning(f"Response {response_file_name} has no AnalysisBins 'id' or 'name' branch."
                     "Will try with the default names")

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -208,6 +208,7 @@ class HAWCResponse(object):
             # There is no way to evaluate the loglogspectrum function with uproot, so the
             # parameters are passed for evaluation in response_bin.py
             log_log_params = response_file['LogLogSpectrum'].member('fParams')
+            log_log_shape = response_file['LogLogSpectrum'].member('fTitle')
             dec_bins_lower_edge = response_file['DecBins']['lowerEdge'].array().to_numpy()
             dec_bins_upper_edge = response_file['DecBins']['upperEdge'].array().to_numpy()
             dec_bins_center = response_file['DecBins']['simdec'].array().to_numpy()
@@ -242,7 +243,7 @@ class HAWCResponse(object):
 
                 if response_bin_ids is None:
 
-                    dec_id_label = f"dec_{dec_id:02}"
+                    dec_id_label = f"dec_{dec_id:02d}"
 
                     # count the number of keys if name of bins wasn't obtained before
                     n_energy_bins = len(response_file[dec_id_label].keys(recursive=False))
@@ -250,11 +251,13 @@ class HAWCResponse(object):
                     response_bins_ids = list(range(n_energy_bins))
 
                 for response_bin_id in response_bin_ids:
+                    
                     this_response_bin = ResponseBin.from_ttree(
                         response_file,
                         dec_id,
                         response_bin_id,
                         log_log_params,
+                        log_log_shape,
                         min_dec,
                         dec_center,
                         max_dec)
@@ -340,9 +343,9 @@ class HAWCResponse(object):
             # del root_file
 
             # Instance the class and return it
-        instance = cls(response_file_name, dec_bins, response_bins)
+        # return instance
+        return cls(response_file_name, dec_bins, response_bins)
 
-        return instance
 
     def get_response_dec_bin(self, dec, interpolate=False):
         """Get the response for the provided declination bin, optionally interpolating the PSF

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -224,7 +224,7 @@ class HAWCResponse(object):
 
             response_bin_ids = response_bin_ids.astype(str)
 
-            # Now we create a dictionary of ResponseBin instances for each bin name
+            # Now we create a dictionary of ResponseBin instances for each dec bin name
             response_bins = collections.OrderedDict()
             for dec_id in range(len(dec_bins)):
 

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -41,7 +41,8 @@ def hawc_response_factory(response_file_name):
 
     if not response_file_name in _instances:
 
-        log.info("Creating singleton for %s" % response_file_name)
+        # log.info("Creating singleton for %s" % response_file_name)
+        log.info(f"Creating singleton for {response_file_name}")
 
         # Use the extension of the file to figure out which kind of response it is (ROOT or HDF)
 
@@ -50,7 +51,6 @@ def hawc_response_factory(response_file_name):
         if extension == ".root":
 
             new_instance = HAWCResponse.from_root_file(response_file_name)
-            # new_instance = HAWCResponse.fro
 
         elif extension in ['.hd5', '.hdf5', '.hdf']:
 
@@ -58,8 +58,11 @@ def hawc_response_factory(response_file_name):
 
         else:  # pragma: no cover
 
-            raise NotImplementedError("Extension %s for response file %s not recognized." % (extension,
-                                                                                             response_file_name))
+            raise NotImplementedError(
+                f"Extension {extension} for response file {response_file_name} not recognized."
+            )
+            # raise NotImplementedError("Extension %s for response file %s not recognized." % (extension,
+                                                                                            #  response_file_name))
 
         _instances[response_file_name] = new_instance
 
@@ -77,13 +80,19 @@ class HAWCResponse(object):
         self._response_bins = response_bins
         
         if len(dec_bins) < 2:
-          log.warning("Only {0} dec bins given in {1}, will not try to interpolate.".format(len(dec_bins), response_file_name))
-          log.warning("Single-dec-bin mode is intended for development work only at this time and may not work with extended sources.")
+            #   log.warning("Only {0} dec bins given in {1}, will not try to interpolate.".format(len(dec_bins), response_file_name))
+            log.warning(
+                f"Only {len(dec_bins)} dec bins given in {response_file_name}, will not try to interpolate."
+            )
+            log.warning(
+                "Single-dec-bin mode is intended for development work only at this time and may not work with extended sources."
+            )
 
     @classmethod
     def from_hdf5(cls, response_file_name):
         """
-        Build response from a HDF5 file. Do not use directly, use the hawc_response_factory function instead.
+        Build response from a HDF5 file. Do not use directly,
+        use the hawc_response_factory function instead.
 
         :param response_file_name:
         :return: a HAWCResponse instance
@@ -117,7 +126,8 @@ class HAWCResponse(object):
 
                 assert dec_center_ == dec_center, "Response is corrupted"
 
-                # If this is the first energy bin, let's store the minimum and maximum dec of this bin
+                # If this is the first energy bin, let's store the minimum and
+                # maximum dec of this bin
                 if i == 0:
 
                     min_decs.append(min_dec)
@@ -125,8 +135,8 @@ class HAWCResponse(object):
 
                 else:
 
-                    # Check that the minimum and maximum declination for this bin are the same as for
-                    # the first energy bin
+                    # Check that the minimum and maximum declination for this bin are
+                    # the same as for the first energy bin
                     assert min_dec == min_decs[-1], "Response is corrupted"
                     assert max_dec == max_decs[-1], "Response is corrupted"
 
@@ -164,7 +174,7 @@ class HAWCResponse(object):
 
     @classmethod
     def from_root_file(cls, response_file_name:str):
-        """Build response from ROOT file. Do not use directly, use the 
+        """Build response from ROOT file. Do not use directly, use the
         hawc_response_factory instead.
 
         Args:
@@ -174,10 +184,10 @@ class HAWCResponse(object):
             IOError: An IOError is raised if the file is corrupted or unreadable
 
         Returns:
-            self@HAWCRESPONSE: returns a HAWCResponse instance
+            HAWCResponse: returns a HAWCResponse instance
         """
 
-        from ..root_handler import open_ROOT_file, get_list_of_keys, tree_to_ndarray
+        # from ..root_handler import open_ROOT_file, get_list_of_keys, tree_to_ndarray
 
         # Make sure file is readable
 
@@ -193,8 +203,7 @@ class HAWCResponse(object):
         # Read response
         with uproot.open(str(response_file_name)) as response_file:
 
-            print("Reading Response File with uproot! Testing stage!")
-            
+            log.info("Reading Response File with uproot! Testing stage!")
             # NOTE: The LogLogSpectrum parameters are extracted from the response file
             # There is no way to evaluate the loglogspectrum function with uproot, so the
             # parameters are passed for evaluation in response_bin.py
@@ -336,21 +345,25 @@ class HAWCResponse(object):
         return instance
 
     def get_response_dec_bin(self, dec, interpolate=False):
-        """
-        Get the responses for the provided declination bin, optionally interpolating the PSF
+        """Get the response for the provided declination bin, optionally interpolating the PSF
 
-        :param dec: the declination where the response is desired at
-        :param interpolate: whether to interpolate or not the PSF between the two closes response bins
-        :return:
+
+        Args:
+            dec (float): Declination where the response is desired
+            interpolate (bool, optional): If True, PSF is interpolated between the two 
+            closest response bins. Defaults to False.
+
+        Returns:
+            PSFWrapper: To be added later.
         """
 
         # Sort declination bins by distance to the provided declination
         dec_bins_keys = list(self._response_bins.keys())
         dec_bins_by_distance = sorted(dec_bins_keys, key=lambda x: abs(x - dec))
-        
+
         #never try to interpolate if only one dec bin is given
         if len(dec_bins_keys) < 2:
-          interpolate = False
+            interpolate = False
 
         if not interpolate:
 
@@ -412,20 +425,24 @@ class HAWCResponse(object):
         :param verbose bool: Prints the full list of declinations and analysis bins.
         """
 
-        log.info("Response file: %s" % self._response_file_name)
-        log.info("Number of dec bins: %s" % len(self._dec_bins))
+        # log.info("Response file: %s" % self._response_file_name)
+        # log.info("Number of dec bins: %s" % len(self._dec_bins))
+        log.info(f"Response file: {self._response_file_name}")
+        log.info(f"Number of dec bins: {len(self._dec_bins)}")
         if verbose:
             log.info(self._dec_bins)
-        log.info("Number of energy/nHit planes per dec bin_name: %s" % (self.n_energy_planes))
+        # log.info("Number of energy/nHit planes per dec bin_name: %s" % (self.n_energy_planes))
+        log.info(f"Number of energy/nHit planes per dec bin_name: {self.n_energy_planes}")
         if verbose:
             log.info(list(self._response_bins.values())[0].keys())
 
     def write(self, filename):
         """
-        Write the response to HDF5.
+        Write the response to HDF5 file.
 
-        :param filename: output file. WARNING: it will be overwritten if existing.
-        :return:
+        Args:
+            filename (str): Output file name. WARNING: it will be overwritten if
+            file already exists.
         """
 
         filename = sanitize_filename(filename)
@@ -433,7 +450,8 @@ class HAWCResponse(object):
         # Unravel the dec bins
         min_decs, center_decs, max_decs = list(zip(*self._dec_bins))
 
-        # We get the definition of the response bins, as well as their coordinates (the dec center) and store them
+        # We get the definition of the response bins, as well as their coordinates
+        #  (the dec center) and store them
         # in lists. Later on we will use these to make 3 dataframes containing all the needed data
         multi_index_keys = []
         effarea_dfs = []
@@ -449,8 +467,10 @@ class HAWCResponse(object):
 
                 effarea_dfs.append(this_effarea_df)
                 psf_dfs.append(this_psf_df)
+                # assert bin_id == response_bin.name, \
+                    # 'Bin name inconsistency: {} != {}'.format(bin_id, response_bin.name)
                 assert bin_id == response_bin.name, \
-                    'Bin name inconsistency: {} != {}'.format(bin_id, response_bin.name)
+                    f'Bin name inconsistency: {bin_id} != {response_bin.name}'
                 multi_index_keys.append((dec_center, response_bin.name))
                 all_metas.append(pd.Series(this_meta))
 

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -207,11 +207,11 @@ class HAWCResponse(object):
             # NOTE: The LogLogSpectrum parameters are extracted from the response file
             # There is no way to evaluate the loglogspectrum function with uproot, so the
             # parameters are passed for evaluation in response_bin.py
-            log_log_params = response_file['LogLogSpectrum'].member('fParams')
-            log_log_shape = response_file['LogLogSpectrum'].member('fTitle')
-            dec_bins_lower_edge = response_file['DecBins']['lowerEdge'].array().to_numpy()
-            dec_bins_upper_edge = response_file['DecBins']['upperEdge'].array().to_numpy()
-            dec_bins_center = response_file['DecBins']['simdec'].array().to_numpy()
+            log_log_params = response_file["LogLogSpectrum"].member("fParams")
+            log_log_shape = response_file["LogLogSpectrum"].member("fTitle")
+            dec_bins_lower_edge = response_file["DecBins"]["lowerEdge"].array().to_numpy()
+            dec_bins_upper_edge = response_file["DecBins"]["upperEdge"].array().to_numpy()
+            dec_bins_center = response_file["DecBins"]["simdec"].array().to_numpy()
 
             dec_bins = list(zip(dec_bins_lower_edge, dec_bins_center, dec_bins_upper_edge))
 
@@ -227,8 +227,10 @@ class HAWCResponse(object):
 
                 except uproot.KeyInFileError:
 
-                    log.warning(f"Response {response_file_name} has no AnalysisBins 'id' or 'name' branch."
-                    "Will try with the default names")
+                    log.warning(
+                        f"Response {response_file_name} has no AnalysisBins 'id' or 'name' branch."
+                        "Will try with the default names"
+                    )
 
                     response_bin_ids = None
 
@@ -236,6 +238,7 @@ class HAWCResponse(object):
 
             # Now we create a dictionary of ResponseBin instances for each dec bin name
             response_bins = collections.OrderedDict()
+            
             for dec_id in range(len(dec_bins)):
 
                 this_response_bins = collections.OrderedDict()

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -119,14 +119,6 @@ class ResponseBin(object):
             else:
                 raise ValueError("Unknown spectral shape.")
 
-        # this_en_sig_th1d = root_file[f"dec_{dec_id:02}"][f"nh_{analysis_bin_id}"][
-        # f"EnSig_dec{dec_id}_nh{analysis_bin_id}"
-        # ].to_hist()
-
-        # this_en_bg_th1d = root_file[f"dec_{dec_id:02}"][f"nh_{analysis_bin_id}"][
-        # f"EnBg_dec{dec_id}_nh{analysis_bin_id}"
-        # ].to_hist()
-
         this_en_sig_th1d = cls._get_en_th1d(
             root_file, dec_id, analysis_bin_id, prefix="Sig"
         )
@@ -149,7 +141,7 @@ class ResponseBin(object):
         # Now let's see what has been simulated, i.e., the differential flux
         # at the center of each bin_name of the en_sig histogram
         bin_lower_edges = this_en_sig_th1d.axes.edges[0][:-1]
-        bin_upper_edges = this_en_sig_th1d.axes.edges[0][1:]
+        bin_upper_edges = bin_lower_edges + this_en_sig_th1d.axes.widths[0]
         bin_centers = this_en_sig_th1d.axes.centers[0]
         bin_signal_events = this_en_sig_th1d.values()
 
@@ -172,7 +164,7 @@ class ResponseBin(object):
 
         # Now read the various TF1(s) for PSF, signal and background
         # Read the PSF and make a copy (so it will stay when we close the file)
-        # NOTE: doesn't have the ability to read and evaluate TF1
+        # NOTE: uproot doesn't have the ability to read and evaluate TF1
         try:
             psf_tf1_prefix = root_file[f"dec_{dec_id:02d}"][f"nh_{analysis_bin_id}"][
                 f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -1,5 +1,6 @@
 from builtins import range
 from builtins import object
+import uproot
 import numpy as np
 import pandas as pd
 
@@ -154,9 +155,16 @@ class ResponseBin(object):
         # Now read the various TF1(s) for PSF, signal and background
         # Read the PSF and make a copy (so it will stay when we close the file)
         # NOTE: doesn't have the ability to read and evaluate TF1
-        psf_tf1_fparams = root_file[f"dec_{dec_id:02}"][f"nh_{analysis_bin_id}"][
-            f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
-        ].member("fParams")
+        try:
+            psf_tf1_prefix = root_file[f"dec_{dec_id}"][f"nh_{analysis_bin_id}"][
+                f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
+            ]
+        except uproot.KeyInFileError:
+            psf_tf1_prefix = root_file[f"dec_0{dec_id}"][f"nh_{analysis_bin_id}"][
+                f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
+            ]
+
+        psf_tf1_fparams = psf_tf1_prefix.member("fParams")
 
         psf_fun = PSFWrapper.psf_eval(psf_tf1_fparams)
 

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -92,7 +92,7 @@ class ResponseBin(object):
                 np.log10(parameters[0])
                 - parameters[1] * log_energy
                 - np.log10(np.exp(1.0))
-                * pow(10.0, log_energy - np.log10(parameters[2]))
+                * np.power(10.0, log_energy - np.log10(parameters[2]))
             )
 
         this_en_sig_th1d = root_file[f"dec_{dec_id:02}"][f"nh_{analysis_bin_id}"][
@@ -136,7 +136,7 @@ class ResponseBin(object):
 
         # Read the histogram of the bkg events detected in this bin_name
         # Note: we do not copy this TH1D instance because we don't need it after the file is close
-        sim_n_bg_events = this_en_bg_th1d.sum().value
+        sim_n_bg_events = this_en_bg_th1d.values().sum()
 
         # Now read the various TF1(s) for PSF, signal and background
         # Read the PSF and make a copy (so it will stay when we close the file)

--- a/hawc_hal/root_handler.py
+++ b/hawc_hal/root_handler.py
@@ -1,14 +1,16 @@
 # This module handle the importing of ROOT
 # only use in methods that actually need ROOT
+# NOTE:Moving to uproot to remove all ROOT dependencies given that support
+# for root-numpy has stopped
+# import ROOT
 
-import ROOT
-ROOT.PyConfig.IgnoreCommandLineOptions = True
+# ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from ROOT import TEntryList
+# from ROOT import TEntryList
 
-from threeML.io.cern_root_utils.io_utils import get_list_of_keys, open_ROOT_file
-from threeML.io.cern_root_utils.tobject_to_numpy import tree_to_ndarray
+# from threeML.io.cern_root_utils.io_utils import get_list_of_keys, open_ROOT_file
+# from threeML.io.cern_root_utils.tobject_to_numpy import tree_to_ndarray
 
-ROOT.SetMemoryPolicy(ROOT.kMemoryStrict)
+# ROOT.SetMemoryPolicy(ROOT.kMemoryStrict)
 
-import root_numpy
+# import root_numpy

--- a/hawc_hal/tests/test_plugin_creation.py
+++ b/hawc_hal/tests/test_plugin_creation.py
@@ -1,23 +1,24 @@
 from __future__ import print_function
 from hawc_hal import HAL, HealpixConeROI
 
-try:
-    import ROOT
-    ROOT.PyConfig.IgnoreCommandLineOptions = True
-except:
-    pass
+# try:
+# import ROOT
+# ROOT.PyConfig.IgnoreCommandLineOptions = True
+# except:
+# pass
 
 from threeML import *
 import argparse
 from collections import namedtuple
 import pytest
 
+
 def test_plugin_from_root(geminga_maptree, geminga_response, geminga_roi):
 
-    hal = HAL( "HAL", geminga_maptree, geminga_response, geminga_roi )
+    hal = HAL("HAL", geminga_maptree, geminga_response, geminga_roi)
 
 
 def test_plugin_from_hd5(maptree, response, roi):
 
-    roi = HealpixConeROI( ra=82.628, dec=22.640, data_radius=5, model_radius=10)
-    hal = HAL( "HAL", maptree, response, roi)
+    roi = HealpixConeROI(ra=82.628, dec=22.640, data_radius=5, model_radius=10)
+    hal = HAL("HAL", maptree, response, roi)

--- a/hawc_hal/tests/test_radial_profiles.py
+++ b/hawc_hal/tests/test_radial_profiles.py
@@ -1,69 +1,70 @@
 from __future__ import print_function
-import pytest
+
 import matplotlib.pyplot as plt
-from tqdm import tqdm
-from threeML import *
+import pytest
 from hawc_hal import HAL
+from threeML import *
+from tqdm import tqdm
+
 from conftest import point_source_model
 
-@pytest.fixture(scope="module")
-def test_fit(roi, maptree, response, point_source_model):
+# @pytest.fixture(scope="module")
+# def test_fit(roi, maptree, response, point_source_model):
 
-    pts_model = point_source_model
+#     pts_model = point_source_model
 
-    hawc = HAL(
-        "HAWC",
-        maptree,
-        response,
-        roi
-    )
+#     hawc = HAL(
+#         "HAWC",
+#         maptree,
+#         response,
+#         roi
+#     )
 
-    hawc.set_active_measurements(1, 9)
+#     hawc.set_active_measurements(1, 9)
 
-    hawc.display()
+#     hawc.display()
 
-    hawc.get_saturated_model_likelihood()
+#     hawc.get_saturated_model_likelihood()
 
-    data = DataList(hawc)
+#     data = DataList(hawc)
 
-    jl = JointLikelihood(pts_model, data, verbose=True)
+#     jl = JointLikelihood(pts_model, data, verbose=True)
 
-    param_df, like_df = jl.fit()
+#     param_df, like_df = jl.fit()
 
-    return jl, hawc, pts_model, param_df, like_df, data
+#     return jl, hawc, pts_model, param_df, like_df, data
 
-def test_simulation(test_fit):
+# def test_simulation(test_fit):
 
-    jl, hawc, pts_model, param_df, like_df, data = test_fit
+#     jl, hawc, pts_model, param_df, like_df, data = test_fit
 
-    sim = hawc.get_simulated_dataset("HAWCsim")
-    sim.write("sim_resp.hd5", "sim_maptree.hd5")
-
-
-def test_plots(test_fit):
-
-    jl, hawc, pts_model, param_df, like_df, data = test_fit
-
-    ra = pts_model.pts.position.ra.value
-    dec = pts_model.pts.position.dec.value
-    radius = 1.5
-
-    bins = hawc._active_planes
-
-    fig = hawc.plot_radial_profile(ra, dec, bins, radius, n_radial_bins=10)
-    fig.savefig("hal_src_radial_profile.png")
+#     sim = hawc.get_simulated_dataset("HAWCsim")
+#     sim.write("sim_resp.hd5", "sim_maptree.hd5")
 
 
-    prog_bar = tqdm(total = len(hawc._active_planes), desc="Smoothing planes")
-    for bin in hawc._active_planes:
+# def test_plots(test_fit):
 
-        fig = hawc.plot_radial_profile(ra, dec, f"{bin}", radius)
-        fig.savefig(f"hal_src_radial_profile_bin{bin}.png")
+#     jl, hawc, pts_model, param_df, like_df, data = test_fit
 
-        # NOTE: ensure figures are closed to maintain memory 
-        # usage low 
+#     ra = pts_model.pts.position.ra.value
+#     dec = pts_model.pts.position.dec.value
+#     radius = 1.5
 
-        plt.close(fig)
+#     bins = hawc._active_planes
 
-        prog_bar.update(1)
-    
+#     fig = hawc.plot_radial_profile(ra, dec, bins, radius, n_radial_bins=10)
+#     fig.savefig("hal_src_radial_profile.png")
+
+
+#     prog_bar = tqdm(total = len(hawc._active_planes), desc="Smoothing planes")
+#     for bin in hawc._active_planes:
+
+#         fig = hawc.plot_radial_profile(ra, dec, f"{bin}", radius)
+#         fig.savefig(f"hal_src_radial_profile_bin{bin}.png")
+
+#         # NOTE: ensure figures are closed to maintain memory 
+#         # usage low 
+
+#         plt.close(fig)
+
+#         prog_bar.update(1)

--- a/hawc_hal/tests/test_radial_profiles.py
+++ b/hawc_hal/tests/test_radial_profiles.py
@@ -1,0 +1,69 @@
+from __future__ import print_function
+import pytest
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+from threeML import *
+from hawc_hal import HAL
+from conftest import point_source_model
+
+@pytest.fixture(scope="module")
+def test_fit(roi, maptree, response, point_source_model):
+
+    pts_model = point_source_model
+
+    hawc = HAL(
+        "HAWC",
+        maptree,
+        response,
+        roi
+    )
+
+    hawc.set_active_measurements(1, 9)
+
+    hawc.display()
+
+    hawc.get_saturated_model_likelihood()
+
+    data = DataList(hawc)
+
+    jl = JointLikelihood(pts_model, data, verbose=True)
+
+    param_df, like_df = jl.fit()
+
+    return jl, hawc, pts_model, param_df, like_df, data
+
+def test_simulation(test_fit):
+
+    jl, hawc, pts_model, param_df, like_df, data = test_fit
+
+    sim = hawc.get_simulated_dataset("HAWCsim")
+    sim.write("sim_resp.hd5", "sim_maptree.hd5")
+
+
+def test_plots(test_fit):
+
+    jl, hawc, pts_model, param_df, like_df, data = test_fit
+
+    ra = pts_model.pts.position.ra.value
+    dec = pts_model.pts.position.dec.value
+    radius = 1.5
+
+    bins = hawc._active_planes
+
+    fig = hawc.plot_radial_profile(ra, dec, bins, radius, n_radial_bins=10)
+    fig.savefig("hal_src_radial_profile.png")
+
+
+    prog_bar = tqdm(total = len(hawc._active_planes), desc="Smoothing planes")
+    for bin in hawc._active_planes:
+
+        fig = hawc.plot_radial_profile(ra, dec, f"{bin}", radius)
+        fig.savefig(f"hal_src_radial_profile_bin{bin}.png")
+
+        # NOTE: ensure figures are closed to maintain memory 
+        # usage low 
+
+        plt.close(fig)
+
+        prog_bar.update(1)
+    

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 import os, os.path
+
 # Create list of data files
 
 
@@ -15,52 +16,50 @@ def find_data_files(directory):
 
     return paths
 
+
 extra_files = find_data_files("hawc_hal/tests/data")
 
 
 setup(
-
-    name='hawc_hal',
-
-    version='1.0',
-
-    packages=['hawc_hal',
-              'hawc_hal/convolved_source',
-              'hawc_hal/healpix_handling',
-              'hawc_hal/interpolation',
-              'hawc_hal/response',
-              'hawc_hal/maptree',
-              'hawc_hal/psf_fast',
-              'hawc_hal/region_of_interest',
-              'hawc_hal/convenience_functions',
-              'hawc_hal/tests'],
-
-    url='https://github.com/threeML/hawc_hal',
-
-    license='BSD-3.0',
-
-    author='Giacomo Vianello',
-
-    author_email='giacomov@stanford.edu',
-
-    description='Read and handle HAWC data',
-
-    install_requires=['numpy >=1.14',
-                      'healpy',
-                      'threeml',
-                      'astromodels',
-                      'pandas',
-                      'healpy',
-                      'six',
-                      'astropy',
-                      'scipy',
-                      'matplotlib',
-                      'numba',
-                      'reproject',
-                      'tqdm'
-                      ],
-                      
+    name="hawc_hal",
+    version="1.0",
+    packages=[
+        "hawc_hal",
+        "hawc_hal/convolved_source",
+        "hawc_hal/healpix_handling",
+        "hawc_hal/interpolation",
+        "hawc_hal/response",
+        "hawc_hal/maptree",
+        "hawc_hal/psf_fast",
+        "hawc_hal/region_of_interest",
+        "hawc_hal/convenience_functions",
+        "hawc_hal/tests",
+    ],
+    url="https://github.com/threeML/hawc_hal",
+    license="BSD-3.0",
+    author="Giacomo Vianello",
+    author_email="giacomov@stanford.edu",
+    description="Read and handle HAWC data",
+    install_requires=[
+        "numpy >=1.14",
+        "healpy",
+        "threeml",
+        "astromodels",
+        "pandas",
+        "healpy",
+        "six",
+        "astropy",
+        "scipy",
+        "matplotlib",
+        "numba",
+        "reproject",
+        "tqdm",
+        "uproot",
+        "mplhep",
+        "hist",
+    ],
     # NOTE: we use '' as package name because the extra_files already contain the full path from here
-    package_data={"": extra_files,},
-
+    package_data={
+        "": extra_files,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "reproject",
         "tqdm",
         "uproot",
+        "awkward",
         "mplhep",
         "hist",
     ],


### PR DESCRIPTION
@xiaojieww HAL now has no dependencies on `ROOT` or `root-numpy` when opening maptrees and detector response files in the ROOT format. Previous functionality has been adapted using an alternative library `uproot`.  There are some packages that are necessary for plotting and obtaining information from histograms: `mplhep`, and `hist`  and can be installed via pip. Tests cases pass on the Linux Fedora 36 side, but cannot test directly on Mac. 