### PR TITLE
Set number of transits to HAL

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -25,12 +25,17 @@ from threeML.plugin_prototype import PluginPrototype
 from threeML.utils.statistics.gammaln import logfactorial
 from tqdm.auto import tqdm
 
-from hawc_hal.convolved_source import (ConvolvedExtendedSource2D,
-                                       ConvolvedExtendedSource3D,
-                                       ConvolvedPointSource,
-                                       ConvolvedSourcesContainer)
-from hawc_hal.healpix_handling import (FlatSkyToHealpixTransform,
-                                       SparseHealpix, get_gnomonic_projection)
+from hawc_hal.convolved_source import (
+    ConvolvedExtendedSource2D,
+    ConvolvedExtendedSource3D,
+    ConvolvedPointSource,
+    ConvolvedSourcesContainer,
+)
+from hawc_hal.healpix_handling import (
+    FlatSkyToHealpixTransform,
+    SparseHealpix,
+    get_gnomonic_projection,
+)
 from hawc_hal.log_likelihood import log_likelihood
 from hawc_hal.maptree import map_tree_factory
 from hawc_hal.maptree.data_analysis_bin import DataAnalysisBin
@@ -53,19 +58,34 @@ class HAL(PluginPrototype):
     :param flat_sky_pixels_size: size of the pixel for the flat sky projection (Hammer Aitoff)
     """
 
-    def __init__(self, name, maptree, response_file, roi, flat_sky_pixels_size=0.17):
+    def __init__(
+        self,
+        name,
+        maptree,
+        response_file,
+        roi,
+        flat_sky_pixels_size=0.17,
+        set_transits=None,
+    ):
 
         # Store ROI
         self._roi = roi
 
+        # optionally specify n_transits
+        if set_transits is not None:
+            log.info(f"Setting transits to {set_transits}")
+            n_transits = set_transits
+
+        else:
+            n_transits = None
+            log.info("Using transits contained in maptree")
+
         # Set up the flat-sky projection
         self.flat_sky_pixels_size = flat_sky_pixels_size
-        self._flat_sky_projection = self._roi.get_flat_sky_projection(
-            self.flat_sky_pixels_size
-        )
+        self._flat_sky_projection = self._roi.get_flat_sky_projection(self.flat_sky_pixels_size)
 
         # Read map tree (data)
-        self._maptree = map_tree_factory(maptree, roi=self._roi)
+        self._maptree = map_tree_factory(maptree, roi=self._roi, n_transits=n_transits)
 
         # Read detector response_file
         self._response = hawc_response_factory(response_file)
@@ -186,9 +206,7 @@ class HAL(PluginPrototype):
 
     def _setup_psf_convolutors(self):
 
-        central_response_bins = self._response.get_response_dec_bin(
-            self._roi.ra_dec_center[1]
-        )
+        central_response_bins = self._response.get_response_dec_bin(self._roi.ra_dec_center[1])
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
@@ -261,9 +279,7 @@ class HAL(PluginPrototype):
             for this_bin in range(bin_id_min, bin_id_max + 1):
                 this_bin = str(this_bin)
                 if this_bin not in self._all_planes:
-                    raise ValueError(
-                        f"Bin {this_bin} is not contained in this maptree."
-                    )
+                    raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
 
                 self._active_planes.append(this_bin)
 
@@ -281,9 +297,7 @@ class HAL(PluginPrototype):
 
                 # if not this_bin in self._all_planes:
                 if this_bin not in self._all_planes:
-                    raise ValueError(
-                        f"Bin {this_bin} is not contained in this maptree."
-                    )
+                    raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
 
                 self._active_planes.append(this_bin)
 
@@ -438,9 +452,7 @@ class HAL(PluginPrototype):
             # each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_model_map(
-                energy_id, n_point_sources, n_ext_sources
-            ).as_partial()
+            mdl = self._get_model_map(energy_id, n_point_sources, n_ext_sources).as_partial()
 
             # select counts only from the pixels within specifid distance from
             # origin of radial profile
@@ -507,10 +519,7 @@ class HAL(PluginPrototype):
         # The area of each ring is then given by the difference between two
         # subsequent circe areas.
         area = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[0]
-                for r in radii
-            ]
+            [self.get_excess_background(ra, dec, r + offset * delta_r)[0] for r in radii]
         )
 
         temp = area[1:] - area[:-1]
@@ -518,10 +527,7 @@ class HAL(PluginPrototype):
 
         # signals
         signal = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[1]
-                for r in radii
-            ]
+            [self.get_excess_background(ra, dec, r + offset * delta_r)[1] for r in radii]
         )
 
         temp = signal[1:] - signal[:-1]
@@ -529,10 +535,7 @@ class HAL(PluginPrototype):
 
         # backgrounds
         bkg = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[2]
-                for r in radii
-            ]
+            [self.get_excess_background(ra, dec, r + offset * delta_r)[2] for r in radii]
         )
 
         temp = bkg[1:] - bkg[:-1]
@@ -543,10 +546,7 @@ class HAL(PluginPrototype):
         # model
         # convert 'top hat' excess into 'ring' excesses.
         model = np.array(
-            [
-                self.get_excess_background(ra, dec, r + offset * delta_r)[3]
-                for r in radii
-            ]
+            [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
         )
 
         temp = model[1:] - model[:-1]
@@ -557,10 +557,7 @@ class HAL(PluginPrototype):
             self.set_model(model_to_subtract)
 
             model_subtract = np.array(
-                [
-                    self.get_excess_background(ra, dec, r + offset * delta_r)[3]
-                    for r in radii
-                ]
+                [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
             )
 
             temp = model_subtract[1:] - model_subtract[:-1]
@@ -580,17 +577,11 @@ class HAL(PluginPrototype):
         # them to the data later. Weight is normalized (sum of weights over
         # the bins = 1).
 
-        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[
-            good_planes
-        ]
+        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
 
-        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
-            good_planes
-        ]
+        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[good_planes]
 
-        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
-            good_planes
-        ]
+        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[good_planes]
 
         w = np.divide(total_model, total_bkg)
         weight = np.array([w / np.sum(w) for _ in radii])
@@ -644,13 +635,7 @@ class HAL(PluginPrototype):
             values for easy retrieval
         """
 
-        (
-            radii,
-            excess_model,
-            excess_data,
-            excess_error,
-            plane_ids,
-        ) = self.get_radial_profile(
+        (radii, excess_model, excess_data, excess_error, plane_ids,) = self.get_radial_profile(
             ra,
             dec,
             active_planes,
@@ -682,9 +667,7 @@ class HAL(PluginPrototype):
 
         plt.plot(radii, excess_model, color="red", label="Model")
 
-        plt.legend(
-            bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1, fontsize=16
-        )
+        plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1, fontsize=16)
         plt.axhline(0, color="deepskyblue", linestyle="--")
 
         x_limits = [0, max_radius]
@@ -794,9 +777,7 @@ class HAL(PluginPrototype):
 
         yerr = [yerr_high, yerr_low]
 
-        return self._plot_spectrum(
-            net_counts, yerr, model_only, residuals, residuals_err
-        )
+        return self._plot_spectrum(net_counts, yerr, model_only, residuals, residuals_err)
 
     def _plot_spectrum(self, net_counts, yerr, model_only, residuals, residuals_err):
 
@@ -870,9 +851,7 @@ class HAL(PluginPrototype):
             bkg_renorm = list(self._nuisance_parameters.values())[0].value
 
             obs = data_analysis_bin.observation_map.as_partial()  # type: np.array
-            bkg = (
-                data_analysis_bin.background_map.as_partial() * bkg_renorm
-            )  # type: np.array
+            bkg = data_analysis_bin.background_map.as_partial() * bkg_renorm  # type: np.array
 
             this_pseudo_log_like = log_likelihood(obs, bkg, this_model_map_hpx)
 
@@ -965,9 +944,7 @@ class HAL(PluginPrototype):
 
                 # Active plane. Generate new data
                 expectation = self._clone[1][bin_id]
-                new_data = np.random.poisson(
-                    expectation, size=(1, expectation.shape[0])
-                ).flatten()
+                new_data = np.random.poisson(expectation, size=(1, expectation.shape[0])).flatten()
 
                 # Substitute data
                 data_analysis_bin.observation_map.set_new_values(new_data)
@@ -977,18 +954,16 @@ class HAL(PluginPrototype):
         # Adjust the name of the nuisance parameter
         old_name = list(self._clone[0]._nuisance_parameters.keys())[0]
         new_name = old_name.replace(self.name, name)
-        self._clone[0]._nuisance_parameters[new_name] = self._clone[
-            0
-        ]._nuisance_parameters.pop(old_name)
+        self._clone[0]._nuisance_parameters[new_name] = self._clone[0]._nuisance_parameters.pop(
+            old_name
+        )
 
         # Recompute biases
         self._clone[0]._compute_likelihood_biases()
 
         return self._clone[0]
 
-    def _get_expectation(
-        self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources
-    ):
+    def _get_expectation(self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources):
 
         # Compute the expectation from the model
 
@@ -1004,9 +979,7 @@ class HAL(PluginPrototype):
                 psf_integration_method=self._psf_integration_method,
             )
 
-            expectation_from_this_source = (
-                expectation_per_transit * data_analysis_bin.n_transits
-            )
+            expectation_from_this_source = expectation_per_transit * data_analysis_bin.n_transits
 
             if this_model_map is None:
 
@@ -1045,18 +1018,14 @@ class HAL(PluginPrototype):
                 # Only extended sources
 
                 this_model_map = (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(
-                        this_ext_model_map
-                    )
+                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
                     * data_analysis_bin.n_transits
                 )
 
             else:
 
                 this_model_map += (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(
-                        this_ext_model_map
-                    )
+                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
                     * data_analysis_bin.n_transits
                 )
 
@@ -1066,18 +1035,14 @@ class HAL(PluginPrototype):
 
             # First divide for the pixel area because we need to interpolate brightness
             # this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
-            this_model_map = (
-                this_model_map / self._flat_sky_projection.project_plane_pixel_area
-            )
+            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](
                 this_model_map, fill_value=0.0
             )
 
             # Now multiply by the pixel area of the new map to go back to flux
-            this_model_map_hpx *= hp.nside2pixarea(
-                data_analysis_bin.nside, degrees=True
-            )
+            this_model_map_hpx *= hp.nside2pixarea(data_analysis_bin.nside, degrees=True)
 
         else:
 
@@ -1152,9 +1117,7 @@ class HAL(PluginPrototype):
             this_ra, this_dec = self._roi.ra_dec_center
 
             # Make a full healpix map for a second
-            whole_map = self._get_model_map(
-                plane_id, n_point_sources, n_ext_sources
-            ).as_dense()
+            whole_map = self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
 
             # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
             longitude = ra_to_longitude(this_ra)
@@ -1163,9 +1126,7 @@ class HAL(PluginPrototype):
             latitude = this_dec
 
             # Background and excess maps
-            bkg_subtracted, _, background_map = self._get_excess(
-                data_analysis_bin, all_maps=True
-            )
+            bkg_subtracted, _, background_map = self._get_excess(data_analysis_bin, all_maps=True)
 
             # Make all the projections: model, excess, background, residuals
             proj_model = self._represent_healpix_map(
@@ -1199,15 +1160,11 @@ class HAL(PluginPrototype):
             vmax = max(np.nanmax(proj_model), np.nanmax(proj_data))
 
             # Plot model
-            images[0] = subs[i][0].imshow(
-                proj_model, origin="lower", vmin=vmin, vmax=vmax
-            )
+            images[0] = subs[i][0].imshow(proj_model, origin="lower", vmin=vmin, vmax=vmax)
             subs[i][0].set_title("model, bin {}".format(data_analysis_bin.name))
 
             # Plot data map
-            images[1] = subs[i][1].imshow(
-                proj_data, origin="lower", vmin=vmin, vmax=vmax
-            )
+            images[1] = subs[i][1].imshow(proj_data, origin="lower", vmin=vmin, vmax=vmax)
             subs[i][1].set_title("excess, bin {}".format(data_analysis_bin.name))
 
             # Plot background map.
@@ -1330,9 +1287,7 @@ class HAL(PluginPrototype):
             raise ValueError(f"{plane_id} not a plane in the current model")
 
         model_map = SparseHealpix(
-            self._get_expectation(
-                self._maptree[plane_id], plane_id, n_pt_src, n_ext_src
-            ),
+            self._get_expectation(self._maptree[plane_id], plane_id, n_pt_src, n_ext_src),
             self._active_pixels[plane_id],
             self._maptree[plane_id].observation_map.nside,
         )
@@ -1406,17 +1361,13 @@ class HAL(PluginPrototype):
         if return_map:
             return new_map_tree
 
-    def write_model_map(
-        self, file_name, poisson_fluctuate=False, test_return_map=False
-    ):
+    def write_model_map(self, file_name, poisson_fluctuate=False, test_return_map=False):
         """
         This function writes the model map to a file.
         The interface is based off of HAWCLike for consistency
         """
         if test_return_map:
-            log.warning(
-                "test_return_map=True should only be used for testing purposes!"
-            )
+            log.warning("test_return_map=True should only be used for testing purposes!")
         return self._write_a_map(file_name, "model", poisson_fluctuate, test_return_map)
 
     def write_residual_map(self, file_name, test_return_map=False):
@@ -1425,7 +1376,5 @@ class HAL(PluginPrototype):
         The interface is based off of HAWCLike for consistency
         """
         if test_return_map:
-            log.warning(
-                "test_return_map=True should only be used for testing purposes!"
-            )
+            log.warning("test_return_map=True should only be used for testing purposes!")
         return self._write_a_map(file_name, "residual", False, test_return_map)

--- a/hawc_hal/maptree/from_hdf5_file.py
+++ b/hawc_hal/maptree/from_hdf5_file.py
@@ -76,9 +76,9 @@ def from_hdf5_file(map_tree_file, roi, transits):
 
     n_transits = meta_df["n_transits"].max() if transits is None else transits
 
-    assert (
-        n_transits <= meta_df["transits"].max()
-    ), "Cannot use higher value than that of maptree"
+    # assert (
+    #     n_transits <= meta_df["transits"].max()
+    # ), "Cannot use higher value than that of maptree"
 
     for bin_name in bin_names:
 

--- a/hawc_hal/maptree/from_hdf5_file.py
+++ b/hawc_hal/maptree/from_hdf5_file.py
@@ -74,11 +74,11 @@ def from_hdf5_file(map_tree_file, roi, transits):
 
     data_analysis_bins = collections.OrderedDict()
 
-    assert (
-        transits <= meta_df["transits"].max()
-    ), "Cannot use higher value than that of maptree"
-
     n_transits = meta_df["n_transits"].max() if transits is None else transits
+
+    assert (
+        n_transits <= meta_df["transits"].max()
+    ), "Cannot use higher value than that of maptree"
 
     for bin_name in bin_names:
 

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -1,63 +1,32 @@
 from __future__ import absolute_import
-from builtins import map
-from builtins import str
-from builtins import range
-from itertools import count
-import os
-from pathlib import Path
-import socket
+
 import collections
+import os
+import socket
+from builtins import map, range, str
+from itertools import count
+from pathlib import Path
 from token import N_TOKENS
+
 import healpy as hp
-from matplotlib.style import library
 import numpy as np
 import uproot
-
+from matplotlib.style import library
 from threeML.io.file_utils import file_existing_and_readable, sanitize_filename
-
 from threeML.io.logging import setup_logger
 
 log = setup_logger(__name__)
 log.propagate = False
 
+from ..healpix_handling import DenseHealpix, SparseHealpix
 from ..region_of_interest import HealpixROIBase
 from .data_analysis_bin import DataAnalysisBin
-
-from ..healpix_handling import SparseHealpix, DenseHealpix
-
-# ! As of right now, any code with ROOT functionality is commented,
-# ! but should be removed in the future.
-# def _get_bin_object(f, bin_name, suffix):
-
-#     # kludge: some maptrees have bin labels in BinInfo like "0", "1", "2", but then
-#     # the nHit bin is actually "nHit00, nHit01, nHit02... others instead have
-#     # labels in BinInfo like "00", "01", "02", and still the nHit bin is nHit00, nHit01
-#     # thus we need to add a 0 to the former case, but not add it to the latter case
-
-#     # bin_label = "nHit0%s/%s" % (bin_name, suffix)
-#     bin_label = f"nHit0{bin_name}/{suffix}"
-
-#     bin_tobject = f.Get(bin_label)
-
-#     if not bin_tobject:
-
-#         # Try the other way
-#         # bin_label = "nHit%s/%s" % (bin_name, suffix)
-#         bin_label = f"nHit{bin_name}/{suffix}"
-
-#         bin_tobject = f.Get(bin_label)
-
-#         if not bin_tobject:
-
-#             # raise IOError("Could not read bin %s" % bin_label)
-#             raise IOError(f"Could not read bin {bin_label}")
-
-#     return bin_tobject
 
 
 def from_root_file(
     map_tree_file: Path,
     roi: HealpixROIBase,
+    transits: float,
     scheme: int = 0,
 ):
     """Create a Maptree object from a ROOT file and a ROI.
@@ -112,14 +81,12 @@ def from_root_file(
 
         try:
 
-            # data_bins_labels = map_infile["BinInfo"]["name"].array().to_numpy()
             data_bins_labels = map_infile["BinInfo/name"].array().to_numpy()
 
         except ValueError:
 
             try:
 
-                # data_bins_labels = map_infile["BinInfo"]["id"].array().to_numpy()
                 data_bins_labels = map_infile["BinInfo/id"].array().to_numpy()
 
             except ValueError as exc:
@@ -135,12 +102,6 @@ def from_root_file(
 
             npix_cnt = map_infile[data_tree_prefix].array().to_numpy().size
             npix_bkg = map_infile[bkg_tree_prefix].array().to_numpy().size
-            # npix_cnt = (
-            # map_infile[f"nHit{bin_name}"]["data"]["count"].array().to_numpy().size
-            # )
-            # npix_bkg = (
-            # map_infile[f"nHit{bin_name}"]["bkg"]["count"].array().to_numpy().size
-            # )
 
         except uproot.KeyInFileError:
             data_tree_prefix = f"nHit0{bin_name}/data/count"
@@ -149,21 +110,16 @@ def from_root_file(
             npix_cnt = map_infile[data_tree_prefix].array().to_numpy().size
             npix_bkg = map_infile[bkg_tree_prefix].array().to_numpy().size
 
-            # npix_cnt = (
-            # map_infile[f"nHit0{bin_name}"]["data"]["count"].array().to_numpy().size
-            # )
-            # npix_bkg = (
-            # map_infile[f"nHit0{bin_name}"]["bkg"]["count"].array().to_numpy().size
-            # )
-
         # The map-maker underestimate the livetime of bins with low statistic
         # by removing time intervals with zero events. Therefore, the best
         # estimate of the livetime is the maximum of n_transits, which normally
         # happen in the bins with high statistic
-        # n_durations = np.divide(map_infile["BinInfo"]["totalDuration"].array(), 24.0)
         maptree_durations = map_infile["BinInfo/totalDuration"].array()
-        n_durations = np.divide(maptree_durations, 24.0)
-        n_transits: float = max(n_durations)
+        if transits is not None:
+            n_transits = transits
+        else:
+            n_durations: np.ndarray = np.divide(maptree_durations, 24.0)
+            n_transits: float = max(n_durations)
 
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
@@ -171,9 +127,7 @@ def from_root_file(
 
         # so far, a value of Nside of 1024  (perhaps will change) and a
         # RING HEALPix
-        assert (
-            nside_cnt == nside_bkg
-        ), "Nside value needs to be the same for counts and bkg. maps"
+        assert nside_cnt == nside_bkg, "Nside value needs to be the same for counts and bkg. maps"
 
         assert scheme == 0, "NESTED HEALPix is not currently supported."
 
@@ -184,9 +138,7 @@ def from_root_file(
         # HACK: simple way of reading the number of active pixels within
         # the define ROI
         if roi is not None:
-            active_pixels = roi.active_pixels(
-                nside_cnt, system="equatorial", ordering="RING"
-            )
+            active_pixels = roi.active_pixels(nside_cnt, system="equatorial", ordering="RING")
 
             for pix_id in active_pixels:
 
@@ -203,8 +155,6 @@ def from_root_file(
 
                 counts = map_infile[data_tree_prefix].array().to_numpy()
                 bkg = map_infile[bkg_tree_prefix].array().to_numpy()
-                # counts = map_infile[f"nHit{name}"]["data"]["count"].array().to_numpy()
-                # bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array().to_numpy()
 
             except uproot.KeyInFileError:
 
@@ -214,8 +164,6 @@ def from_root_file(
 
                 counts = map_infile[data_tree_prefix].array().to_numpy()
                 bkg = map_infile[bkg_tree_prefix].array().to_numpy()
-                # counts = map_infile[f"nHit0{name}"]["data"]["count"].array().to_numpy()
-                # bkg = map_infile[f"nHit0{name}"]["bkg"]["count"].array().to_numpy()
 
             # Read only elements within the ROI
             if roi is not None:
@@ -226,9 +174,7 @@ def from_root_file(
                 counts_hpx = SparseHealpix(
                     counts[healpix_map_active > 0], active_pixels, nside_cnt
                 )
-                bkg_hpx = SparseHealpix(
-                    bkg[healpix_map_active > 0], active_pixels, nside_cnt
-                )
+                bkg_hpx = SparseHealpix(bkg[healpix_map_active > 0], active_pixels, nside_cnt)
 
                 this_data_analysis_bin = DataAnalysisBin(
                     name,
@@ -242,21 +188,6 @@ def from_root_file(
             # Read the whole sky
             else:
 
-                # try:
-
-                #     counts = (
-                #         map_infile[f"nHit{name}"]["data"]["count"].array().to_numpy()
-                #     )
-                #     bkg = map_infile[f"nHit{name}"]["bkg"]["count"].array().to_numpy()
-
-                # except uproot.KeyInFileError:
-
-                #     # Sometimes, names of bins carry an extra zero
-                #     counts = (
-                #         map_infile[f"nHit0{name}"]["data"]["count"].array().to_numpy()
-                #     )
-                #     bkg = map_infile[f"nHit0{name}"]["bkg"]["count"].array().to_numpy()
-
                 this_data_analysis_bin = DataAnalysisBin(
                     name,
                     DenseHealpix(counts),
@@ -268,165 +199,4 @@ def from_root_file(
 
             data_analysis_bins[name] = this_data_analysis_bin
 
-            # # Read map tree
-            # with open_ROOT_file(str(map_tree_file)) as f:
-
-            #     # Newer maps use "name" rather than "id"
-            #     try:
-
-            #         data_bins_labels = list(root_numpy.tree2array(f.Get("BinInfo"), "name"))
-
-            #     except ValueError:
-
-            #         # Check to see if its an old style maptree
-            #         try:
-
-            #             data_bins_labels = list(root_numpy.tree2array(f.Get("BinInfo"), "id"))
-
-            #         except ValueError:
-
-            #             # Give a useful error message
-            #             raise ValueError("Maptree has no Branch: 'id' or 'name' ")
-
-            #         # If the old style, we need to make them strings
-            #         data_bins_labels = [str(i) for i in data_bins_labels]
-
-            #     # A transit is defined as 1 day, and totalDuration is in hours
-            #     # Get the number of transit from bin 0 (as LiFF does)
-
-            #     n_transits = root_numpy.tree2array(f.Get("BinInfo"), "totalDuration") / 24.0
-
-            #     # The map-maker underestimate the livetime of bins with low statistic by removing time intervals with
-            #     # zero events. Therefore, the best estimate of the livetime is the maximum of n_transits, which normally
-            #     # happen in the bins with high statistic
-            #     n_transits = max(n_transits)
-
-            #     n_bins = len(data_bins_labels)
-
-            #     # These are going to be Healpix maps, one for each data analysis bin_name
-
-            #     data_analysis_bins = collections.OrderedDict()
-
-            #     for i in range(n_bins):
-
-            #         name = data_bins_labels[i]
-
-            #         data_tobject = _get_bin_object(f, name, "data")
-
-            #         bkg_tobject = _get_bin_object(f, name, "bkg")
-
-            #         # Get ordering scheme
-            #         nside = data_tobject.GetUserInfo().FindObject("Nside").GetVal()
-            #         nside_bkg = bkg_tobject.GetUserInfo().FindObject("Nside").GetVal()
-
-            #         assert nside == nside_bkg
-
-            #         scheme = data_tobject.GetUserInfo().FindObject("Scheme").GetVal()
-            #         scheme_bkg = bkg_tobject.GetUserInfo().FindObject("Scheme").GetVal()
-
-            #         assert scheme == scheme_bkg
-
-            #         assert scheme == 0, "NESTED scheme is not supported yet"
-
-            #         if roi is not None:
-
-            #             # Only read the elements in the ROI
-
-            #             active_pixels = roi.active_pixels(
-            #                 nside, system="equatorial", ordering="RING"
-            #             )
-
-            #             counts = _read_partial_tree(data_tobject, active_pixels)
-            #             bkg = _read_partial_tree(bkg_tobject, active_pixels)
-
-            #             counts_hpx = SparseHealpix(counts, active_pixels, nside)
-            #             bkg_hpx = SparseHealpix(bkg, active_pixels, nside)
-
-            #             this_data_analysis_bin = DataAnalysisBin(
-            #                 name,
-            #                 counts_hpx,
-            #                 bkg_hpx,
-            #                 active_pixels_ids=active_pixels,
-            #                 n_transits=n_transits,
-            #                 scheme="RING",
-            #             )
-
-            #         else:
-
-            #             # Read the entire sky.
-
-            #             counts = tree_to_ndarray(data_tobject, "count").astype(np.float64)
-            #             bkg = tree_to_ndarray(bkg_tobject, "count").astype(np.float64)
-
-            #             this_data_analysis_bin = DataAnalysisBin(
-            #                 name,
-            #                 DenseHealpix(counts),
-            #                 DenseHealpix(bkg),
-            #                 active_pixels_ids=None,
-            #                 n_transits=n_transits,
-            #                 scheme="RING",
-            #             )
-            #
-            # data_analysis_bins[name] = this_data_analysis_bin
-    return data_analysis_bins
-
-
-# def _read_partial_tree(ttree_instance, elements_to_read):
-
-#     # Decide whether to use a smart loading scheme, or just loading the whole thing, based on the
-#     # number of elements to be read
-
-#     from ..root_handler import ROOT, root_numpy, tree_to_ndarray
-
-#     if elements_to_read.shape[0] < 500000:
-
-#         # Use a smart loading scheme, where we read only the pixels we need
-
-#         # The fastest method that I found is to create a TEventList, apply it to the
-#         # tree, get a copy of the subset and then use ttree2array
-
-#         # Create TEventList
-#         entrylist = ROOT.TEntryList()
-
-#         # Add the selections
-#         _ = list(map(entrylist.Enter, elements_to_read))
-
-#         # Apply the EntryList to the tree
-#         ttree_instance.SetEntryList(entrylist)
-
-#         # Get copy of the subset
-#         # We need to create a dumb TFile to silence a lot of warnings from ROOT
-#         # Get a filename for this process
-#         dumb_tfile_name = "__dumb_tfile_%s_%s.root" % (
-#             os.getpid(),
-#             socket.gethostname(),
-#         )
-#         dumb_tfile = ROOT.TFile(dumb_tfile_name, "RECREATE")
-#         new_tree = ttree_instance.CopyTree("")
-
-#         # Actually read it from disk
-#         partial_map = root_numpy.tree2array(new_tree, "count").astype(np.float64)
-
-#         # Now reset the entry list
-#         ttree_instance.SetEntryList(0)
-
-#         dumb_tfile.Close()
-#         os.remove(dumb_tfile_name)
-
-#     else:
-
-#         # The smart scheme starts to become slower than the brute force approach, so let's read the whole thing
-#         partial_map = tree_to_ndarray(ttree_instance, "count").astype(np.float64)
-
-#         assert (
-#             partial_map.shape[0] >= elements_to_read.shape[0]
-#         ), "Trying to read more pixels than present in TTree"
-
-#         # Unless we have read the whole sky, let's remove the pixels we shouldn't have read
-
-#         if elements_to_read.shape[0] != partial_map.shape[0]:
-
-#             # Now let's remove the pixels we shouldn't have read
-#             partial_map = partial_map[elements_to_read]
-
-#     return partial_map.astype(np.float64)
+    return data_analysis_bins, n_transits

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -115,10 +115,14 @@ def from_root_file(
         # estimate of the livetime is the maximum of n_transits, which normally
         # happen in the bins with high statistic
         maptree_durations = map_infile["BinInfo/totalDuration"].array()
+        n_durations: np.ndarray = np.divide(maptree_durations, 24.0)
+
         if transits is not None:
+
             n_transits = transits
+
         else:
-            n_durations: np.ndarray = np.divide(maptree_durations, 24.0)
+
             n_transits: float = max(n_durations)
 
         n_bins: int = data_bins_labels.shape[0]
@@ -138,6 +142,7 @@ def from_root_file(
         # HACK: simple way of reading the number of active pixels within
         # the define ROI
         if roi is not None:
+
             active_pixels = roi.active_pixels(nside_cnt, system="equatorial", ordering="RING")
 
             for pix_id in active_pixels:
@@ -153,8 +158,14 @@ def from_root_file(
                 data_tree_prefix = f"nHit{name}/data/count"
                 bkg_tree_prefix = f"nHit{name}/bkg/count"
 
-                counts = map_infile[data_tree_prefix].array().to_numpy()
-                bkg = map_infile[bkg_tree_prefix].array().to_numpy()
+                # if using number of transitions different from the maptree
+                # then make sure counts are scaled accordingly.
+                counts: np.ndarray = map_infile[data_tree_prefix].array().to_numpy() * (
+                    n_transits / max(n_durations)
+                )
+                bkg: np.ndarray = map_infile[bkg_tree_prefix].array().to_numpy() * (
+                    n_transits / max(n_durations)
+                )
 
             except uproot.KeyInFileError:
 

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -55,7 +55,7 @@ def from_root_file(
     # Check that they exists and can be read
 
     if not file_existing_and_readable(map_tree_file):  # pragma: no cover
-        # raise IOError("MapTree %s does not exist or is not readable" % map_tree_file)
+
         raise IOError(f"MapTree {map_tree_file} does not exist or is not readable")
 
     # Make sure we have a proper ROI (or None)
@@ -117,13 +117,12 @@ def from_root_file(
         maptree_durations = map_infile["BinInfo/totalDuration"].array()
         n_durations: np.ndarray = np.divide(maptree_durations, 24.0)
 
-        if transits is not None:
+        assert transits <= max(
+            n_durations
+        ), "Cannot use a higher value than that of maptree."
 
-            n_transits = transits
-
-        else:
-
-            n_transits: float = max(n_durations)
+        # use value of maptree unless otherwise specified by user
+        n_transits = max(n_durations) if transits is None else transits
 
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
@@ -131,7 +130,9 @@ def from_root_file(
 
         # so far, a value of Nside of 1024  (perhaps will change) and a
         # RING HEALPix
-        assert nside_cnt == nside_bkg, "Nside value needs to be the same for counts and bkg. maps"
+        assert (
+            nside_cnt == nside_bkg
+        ), "Nside value needs to be the same for counts and bkg. maps"
 
         assert scheme == 0, "NESTED HEALPix is not currently supported."
 
@@ -143,7 +144,9 @@ def from_root_file(
         # the define ROI
         if roi is not None:
 
-            active_pixels = roi.active_pixels(nside_cnt, system="equatorial", ordering="RING")
+            active_pixels = roi.active_pixels(
+                nside_cnt, system="equatorial", ordering="RING"
+            )
 
             for pix_id in active_pixels:
 
@@ -185,7 +188,9 @@ def from_root_file(
                 counts_hpx = SparseHealpix(
                     counts[healpix_map_active > 0], active_pixels, nside_cnt
                 )
-                bkg_hpx = SparseHealpix(bkg[healpix_map_active > 0], active_pixels, nside_cnt)
+                bkg_hpx = SparseHealpix(
+                    bkg[healpix_map_active > 0], active_pixels, nside_cnt
+                )
 
                 this_data_analysis_bin = DataAnalysisBin(
                     name,

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -120,9 +120,9 @@ def from_root_file(
         # use value of maptree unless otherwise specified by user
         n_transits = max(n_durations) if transits is None else transits
 
-        assert n_transits <= max(
-            n_durations
-        ), "Cannot use a higher value than that of maptree."
+        # assert n_transits <= max(
+        #     n_durations
+        # ), "Cannot use a higher value than that of maptree."
 
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -117,12 +117,12 @@ def from_root_file(
         maptree_durations = map_infile["BinInfo/totalDuration"].array()
         n_durations: np.ndarray = np.divide(maptree_durations, 24.0)
 
-        assert transits <= max(
-            n_durations
-        ), "Cannot use a higher value than that of maptree."
-
         # use value of maptree unless otherwise specified by user
         n_transits = max(n_durations) if transits is None else transits
+
+        assert n_transits <= max(
+            n_durations
+        ), "Cannot use a higher value than that of maptree."
 
         n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -1,13 +1,14 @@
 from __future__ import division
-from builtins import zip
-from builtins import object
-from past.utils import old_div
+
 import copy
+from builtins import object, zip
+
 import numpy as np
+import pandas as pd
 import scipy.integrate
 import scipy.interpolate
 import scipy.optimize
-import pandas as pd
+from past.utils import old_div
 
 _INTEGRAL_OUTER_RADIUS = 15.0
 
@@ -29,9 +30,7 @@ class PSFWrapper(object):
 
         # Memorize the total integral (will use it for normalization)
 
-        self._total_integral = self._psf_interpolated.integral(
-            self._xs[0], _INTEGRAL_OUTER_RADIUS
-        )
+        self._total_integral = self._psf_interpolated.integral(self._xs[0], _INTEGRAL_OUTER_RADIUS)
 
         # Now compute the truncation radius, which is a very conservative measurement
         # of the size of the PSF
@@ -91,9 +90,7 @@ class PSFWrapper(object):
 
         f = lambda r: fraction - old_div(self.integral(1e-4, r), self._total_integral)
 
-        radius, status = scipy.optimize.brentq(
-            f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output=True
-        )
+        radius, status = scipy.optimize.brentq(f, 0.005, _INTEGRAL_OUTER_RADIUS, full_output=True)
 
         assert status.converged, "Brentq did not converged"
 
@@ -134,9 +131,7 @@ class PSFWrapper(object):
         new_ys = w1 * self.ys + w2 * other_psf.ys
 
         # Also weight the brightness interpolation points
-        new_br_interp_y = (
-            w1 * self._brightness_interp_y + w2 * other_psf._brightness_interp_y
-        )
+        new_br_interp_y = w1 * self._brightness_interp_y + w2 * other_psf._brightness_interp_y
 
         return PSFWrapper(
             self.xs,
@@ -227,29 +222,6 @@ class PSFWrapper(object):
         new_instance = copy.deepcopy(instance)
 
         return new_instance
-
-    # @classmethod
-    # def from_TF1(cls, tf1_instance):
-    #
-    #     # Annoyingly, some PSFs for some Dec bins (at large Zenith angles) have
-    #     # zero or negative integrals, i.e., they are useless. Return an unusable PSF
-    #     # object in that case
-    #     if tf1_instance.Integral(0, _INTEGRAL_OUTER_RADIUS) <= 0.0:
-    #
-    #         return InvalidPSF()
-    #
-    #     # Make interpolation
-    #     xs = np.logspace(-3, np.log10(_INTEGRAL_OUTER_RADIUS), 500)
-    #     ys = np.array([tf1_instance.Eval(x) for x in xs], float)
-    #
-    #     assert np.all(np.isfinite(xs))
-    #     assert np.all(np.isfinite(ys))
-    #
-    #     instance = cls(xs, ys)
-    #
-    #     instance._tf1 = tf1_instance.Clone()
-    #
-    #     return instance
 
     def integral(self, a, b):
 

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -50,29 +50,20 @@ class ResponseBin(object):
         prefix: str,
     ):
 
-        # en_sig_label = "En%s_dec%i_nh%s" % (prefix, dec_id, analysis_bin_id)
         en_sig_label = f"En{prefix}_dec{dec_id}_nh{analysis_bin_id}"
 
-        # this_en_th1d = open_ttree.FindObjectAny(en_sig_label)
         try:
             hist_prefix = f"dec_{dec_id:02d}/nh_{analysis_bin_id}/{en_sig_label}"
             this_en_th1d = open_ttree[hist_prefix].to_hist()
-            # this_en_th1d = open_ttree[f"dec_{dec_id:02d}"][f"nh_{analysis_bin_id}"][
-            #    en_sig_label
-            # ].to_hist()
 
         except uproot.KeyInFileError:
 
             hist_prefix = f"dec_{dec_id:02d}/nh_0{analysis_bin_id}/{en_sig_label}"
             this_en_th1d = open_ttree[hist_prefix].to_hist()
-            # this_en_th1d = open_ttree[f"dec_{dec_id:02d}"][f"nh_0{analysis_bin_id}"][
-            #    en_sig_label
-            # ].to_hist()
 
         if not this_en_th1d:
 
             raise IOError(f"Could not find TH1D named {en_sig_label}.")
-            # raise IOError("Could not find TH1D named %s." % en_sig_label)
 
         return this_en_th1d
 
@@ -121,20 +112,15 @@ class ResponseBin(object):
                 return (
                     np.log10(parameters[0])
                     - parameters[1] * log_energy
-                    - np.log10(np.exp(1.0))
-                    * np.power(10.0, log_energy - np.log10(parameters[2]))
+                    - np.log10(np.exp(1.0)) * np.power(10.0, log_energy - np.log10(parameters[2]))
                 )
 
             else:
                 raise ValueError("Unknown spectral shape.")
 
-        this_en_sig_th1d = cls._get_en_th1d(
-            root_file, dec_id, analysis_bin_id, prefix="Sig"
-        )
+        this_en_sig_th1d = cls._get_en_th1d(root_file, dec_id, analysis_bin_id, prefix="Sig")
 
-        this_en_bg_th1d = cls._get_en_th1d(
-            root_file, dec_id, analysis_bin_id, prefix="Bg"
-        )
+        this_en_bg_th1d = cls._get_en_th1d(root_file, dec_id, analysis_bin_id, prefix="Bg")
 
         total_bins = this_en_sig_th1d.shape[0]
         sim_energy_bin_low = np.zeros(total_bins)
@@ -177,22 +163,11 @@ class ResponseBin(object):
         try:
 
             psf_prefix = f"dec_{dec_id:02d}/nh_{analysis_bin_id}"
-            psf_tf1_metadata = root_file[
-                f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
-            ]
-            # psf_tf1_metadata = root_file[f"dec_{dec_id:02d}"][f"nh_{analysis_bin_id}"][
-            #    f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
-            # ]
+            psf_tf1_metadata = root_file[f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"]
         except uproot.KeyInFileError:
 
             psf_prefix = f"dec_{dec_id:02d}/nh_0{analysis_bin_id}"
-            psf_tf1_metadata = root_file[
-                f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
-            ]
-
-            # psf_tf1_metadata = root_file[f"dec_{dec_id:02d}"][f"nh_0{analysis_bin_id}"][
-            #    f"PSF_dec{dec_id}_nh{analysis_bin_id}_fit"
-            # ]
+            psf_tf1_metadata = root_file[f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"]
 
         psf_tf1_fparams = psf_tf1_metadata.member("fParams")
 
@@ -212,94 +187,6 @@ class ResponseBin(object):
             sim_signal_events_per_bin,
             psf_fun,
         )
-
-    # @classmethod
-    # def from_ttree(
-    #     cls,
-    #     open_ttree,
-    #     dec_id,
-    #     analysis_bin_id,
-    #     log_log_spectrum,
-    #     min_dec,
-    #     dec_center,
-    #     max_dec,
-    # ):
-
-    #     from ..root_handler import ROOT
-
-    #     # Read the histogram of the simulated events detected in this bin_name
-    #     # NOTE: we do not copy this TH1D instance because we won't use it after the
-    #     # file is closed
-
-    #     this_en_sig_th1d = cls._get_en_th1d(open_ttree, dec_id, analysis_bin_id, "Sig")
-
-    #     # The sum of the histogram is the total number of simulated events detected
-    #     # in this analysis bin_name
-    #     sim_n_sig_events = this_en_sig_th1d.Integral()
-
-    #     # Now let's see what has been simulated, i.e., the differential flux
-    #     # at the center of each bin_name of the en_sig histogram
-    #     sim_energy_bin_low = np.zeros(this_en_sig_th1d.GetNbinsX())
-    #     sim_energy_bin_centers = np.zeros(this_en_sig_th1d.GetNbinsX())
-    #     sim_energy_bin_hi = np.zeros(this_en_sig_th1d.GetNbinsX())
-    #     sim_signal_events_per_bin = np.zeros_like(sim_energy_bin_centers)
-    #     sim_differential_photon_fluxes = np.zeros_like(sim_energy_bin_centers)
-
-    #     for i in range(sim_energy_bin_centers.shape[0]):
-    #         # Remember: bin_name 0 is the underflow bin_name, that is why there
-    #         # is a "i+1" and not just "i"
-    #         bin_lo = this_en_sig_th1d.GetBinLowEdge(i + 1)
-    #         bin_center = this_en_sig_th1d.GetBinCenter(i + 1)
-    #         bin_hi = this_en_sig_th1d.GetBinWidth(i + 1) + bin_lo
-
-    #         # Store the center of the logarithmic bin_name
-    #         sim_energy_bin_low[i] = 10**bin_lo  # TeV
-    #         sim_energy_bin_centers[i] = 10**bin_center  # TeV
-    #         sim_energy_bin_hi[i] = 10**bin_hi  # TeV
-
-    #         # Get from the simulated spectrum the value of the differential flux
-    #         # at the center energy
-    #         sim_differential_photon_fluxes[i] = 10 ** log_log_spectrum.Eval(
-    #             bin_center
-    #         )  # TeV^-1 cm^-1 s^-1
-
-    #         # Get from the histogram the detected events in each log-energy bin_name
-    #         sim_signal_events_per_bin[i] = this_en_sig_th1d.GetBinContent(i + 1)
-
-    #     # Read the histogram of the bkg events detected in this bin_name
-    #     # NOTE: we do not copy this TH1D instance because we won't use it after the
-    #     # file is closed
-
-    #     this_en_bg_th1d = cls._get_en_th1d(open_ttree, dec_id, analysis_bin_id, "Bg")
-
-    #     # The sum of the histogram is the total number of simulated events detected
-    #     # in this analysis bin_name
-    #     sim_n_bg_events = this_en_bg_th1d.Integral()
-
-    #     # Now read the various TF1(s) for PSF, signal and background
-
-    #     # Read the PSF and make a copy (so it will stay when we close the file)
-
-    #     psf_label_tf1 = "PSF_dec%i_nh%s_fit" % (dec_id, analysis_bin_id)
-
-    #     tf1 = open_ttree.FindObjectAny(psf_label_tf1)
-
-    #     psf_fun = PSFWrapper.from_TF1(tf1)
-
-    #     return cls(
-    #         analysis_bin_id,
-    #         min_dec,
-    #         max_dec,
-    #         dec_center,
-    #         sim_n_sig_events,
-    #         sim_n_bg_events,
-    #         sim_energy_bin_low,
-    #         sim_energy_bin_centers,
-    #         sim_energy_bin_hi,
-    #         sim_differential_photon_fluxes,
-    #         sim_signal_events_per_bin,
-    #         psf_fun,
-    #     )
 
     def to_pandas(self):
         """Save the information from Response file into a pandas.DataFrame
@@ -354,9 +241,7 @@ class ResponseBin(object):
         n_sim_signal_events = (
             w1 * self._sim_n_sig_events + w2 * other_response_bin._sim_n_sig_events
         )
-        n_sim_bkg_events = (
-            w1 * self._sim_n_bg_events + w2 * other_response_bin._sim_n_bg_events
-        )
+        n_sim_bkg_events = w1 * self._sim_n_bg_events + w2 * other_response_bin._sim_n_bg_events
 
         # We assume that the bin centers are the same
         assert np.allclose(

--- a/hawc_hal/tests/test_n_transits.py
+++ b/hawc_hal/tests/test_n_transits.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+from hawc_hal import HealpixConeROI
+from hawc_hal.maptree.map_tree import map_tree_factory
+
+from conftest import check_n_transits
+
+
+def test_transits(maptree, roi):
+    """Specify the number of transits to use with maptree
+
+    Args:
+        maptree (path.Path): Maptree in either ROOT or HDF5 format
+        roi (roi): Region of interest for analysis
+    """
+    roi_ = roi
+
+    # Case 1: specify number of transits
+
+    n_transits = 777.7
+    maptree_ntransits = map_tree_factory(maptree,roi_,n_transits)
+
+    # does the maptree return the specified transits?
+    check_n_transits(maptree_ntransits, n_transits)
+
+    # Case 2: number of transits is not specified (use value from maptree)
+    maptree_unspecifed = map_tree_factory(maptree, roi_)
+    n_transits = maptree_unspecifed.n_transits
+
+    check_n_transits(maptree_unspecifed, n_transits)
+
+    


### PR DESCRIPTION
Adding the ability to set the number of transits to HAL. The transits can be set  in the following way, e.g. 10 transits:
```
 hawc = HAL("HAWC", maptree, detector_response, roi=roi, flat_sky_pixels_size=0.1, set_transits=10)
```
Also added the tests developed by Chad on #43. 