### PR TITLE
Multiprocessing the loading of ROOT files

### DIFF
--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -998,35 +998,6 @@ class HAL(PluginPrototype):
 
         return self._clone[0]
 
-    def _compute_expectation(
-        self,
-        data_analysis_bin: DataAnalysisBin,
-        energy_bin_id: str,
-        convolved_source: Union[
-            ConvolvedPointSource, ConvolvedExtendedSource2D, ConvolvedExtendedSource3D
-        ],
-        this_model_map: Union[float, None],
-    ):
-        expectation_per_transit = convolved_source.get_source_map(
-            energy_bin_id,
-            tag=None,
-            psf_integration_method=self._psf_integration_method,
-        )
-
-        expectation_from_this_source = (
-            expectation_per_transit * data_analysis_bin.n_transits
-        )
-
-        if this_model_map is None:
-            # First addition
-            #
-            this_model_map = expectation_from_this_source
-
-        else:
-            this_model_map += expectation_from_this_source
-
-        return expectation_from_this_source
-
     def _get_expectation(
         self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources
     ):

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -6,17 +6,13 @@ import copy
 from builtins import range, str
 
 import astromodels
-import astropy.units as u
 import healpy as hp
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astromodels import Parameter
 from astropy.convolution import Gaussian2DKernel
 from astropy.convolution import convolve_fft as convolve
-from astropy.coordinates import Angle
-from astropy.utils.misc import isiterable
 from past.utils import old_div
 from scipy.stats import poisson
 from threeML.io.logging import setup_logger
@@ -67,7 +63,6 @@ class HAL(PluginPrototype):
         flat_sky_pixels_size=0.17,
         set_transits=None,
     ):
-
         # Store ROI
         self._roi = roi
 
@@ -82,7 +77,9 @@ class HAL(PluginPrototype):
 
         # Set up the flat-sky projection
         self.flat_sky_pixels_size = flat_sky_pixels_size
-        self._flat_sky_projection = self._roi.get_flat_sky_projection(self.flat_sky_pixels_size)
+        self._flat_sky_projection = self._roi.get_flat_sky_projection(
+            self.flat_sky_pixels_size
+        )
 
         # Read map tree (data)
         self._maptree = map_tree_factory(maptree, roi=self._roi, n_transits=n_transits)
@@ -196,7 +193,6 @@ class HAL(PluginPrototype):
 
     @psf_integration_method.setter
     def psf_integration_method(self, mode):
-
         assert mode.lower() in [
             "exact",
             "fast",
@@ -205,8 +201,9 @@ class HAL(PluginPrototype):
         self._psf_integration_method = mode.lower()
 
     def _setup_psf_convolutors(self):
-
-        central_response_bins = self._response.get_response_dec_bin(self._roi.ra_dec_center[1])
+        central_response_bins = self._response.get_response_dec_bin(
+            self._roi.ra_dec_center[1]
+        )
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
@@ -217,7 +214,6 @@ class HAL(PluginPrototype):
                 )
 
     def _compute_likelihood_biases(self):
-
         for bin_label in self._maptree:
             data_analysis_bin = self._maptree[bin_label]
 
@@ -266,7 +262,6 @@ class HAL(PluginPrototype):
 
         # Check for legal input
         if bin_id_min is not None:
-
             assert (
                 bin_id_max is not None
             ), "If you provide a minimum bin, you also need to provide a maximum bin."
@@ -284,7 +279,6 @@ class HAL(PluginPrototype):
                 self._active_planes.append(this_bin)
 
         else:
-
             assert (
                 bin_id_max is None
             ), "If you provie a maximum bin, you also need to provide a minimum bin."
@@ -294,7 +288,6 @@ class HAL(PluginPrototype):
             self._active_planes = []
 
             for this_bin in bin_list:
-
                 # if not this_bin in self._all_planes:
                 if this_bin not in self._all_planes:
                     raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
@@ -368,21 +361,17 @@ class HAL(PluginPrototype):
 
         # NOTE: ext_sources evaluate to False if empty
         if ext_sources:
-
             # We will need to convolve
 
             self._setup_psf_convolutors()
 
             for source in ext_sources:
-
                 if source.spatial_shape.n_dim == 2:
-
                     this_convolved_ext_source = ConvolvedExtendedSource2D(
                         source, self._response, self._flat_sky_projection
                     )
 
                 else:
-
                     this_convolved_ext_source = ConvolvedExtendedSource3D(
                         source, self._response, self._flat_sky_projection
                     )
@@ -452,7 +441,9 @@ class HAL(PluginPrototype):
             # each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_model_map(energy_id, n_point_sources, n_ext_sources).as_partial()
+            mdl = self._get_model_map(
+                energy_id, n_point_sources, n_ext_sources
+            ).as_partial()
 
             # select counts only from the pixels within specifid distance from
             # origin of radial profile
@@ -557,7 +548,10 @@ class HAL(PluginPrototype):
             self.set_model(model_to_subtract)
 
             model_subtract = np.array(
-                [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
+                [
+                    self.get_excess_background(ra, dec, r + offset * delta_r)[3]
+                    for r in radii
+                ]
             )
 
             temp = model_subtract[1:] - model_subtract[:-1]
@@ -577,11 +571,15 @@ class HAL(PluginPrototype):
         # them to the data later. Weight is normalized (sum of weights over
         # the bins = 1).
 
-        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
+        np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
 
-        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[good_planes]
+        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
+            good_planes
+        ]
 
-        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[good_planes]
+        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
+            good_planes
+        ]
 
         w = np.divide(total_model, total_bkg)
         weight = np.array([w / np.sum(w) for _ in radii])
@@ -635,7 +633,13 @@ class HAL(PluginPrototype):
             values for easy retrieval
         """
 
-        (radii, excess_model, excess_data, excess_error, plane_ids,) = self.get_radial_profile(
+        (
+            radii,
+            excess_model,
+            excess_data,
+            excess_error,
+            plane_ids,
+        ) = self.get_radial_profile(
             ra,
             dec,
             active_planes,
@@ -727,7 +731,6 @@ class HAL(PluginPrototype):
         yerr_high = np.zeros_like(total_counts)
 
         for i, energy_id in enumerate(self._active_planes):
-
             data_analysis_bin = self._maptree[energy_id]
 
             this_model_map_hpx = self._get_expectation(
@@ -746,7 +749,6 @@ class HAL(PluginPrototype):
             total_model[i] = this_wh_model
 
             if this_data_tot >= 50.0:
-
                 # Gaussian limit
                 # Under the null hypothesis the data are distributed as a Gaussian with mu = model
                 # and sigma = sqrt(model)
@@ -756,7 +758,6 @@ class HAL(PluginPrototype):
                 yerr_high[i] = np.sqrt(this_data_tot)
 
             else:
-
                 # Low-counts
                 # Under the null hypothesis the data are distributed as a Poisson distribution with
                 # mean = model, plot the 68% confidence interval (quantile=[0.16,1-0.16]).
@@ -780,7 +781,6 @@ class HAL(PluginPrototype):
         return self._plot_spectrum(net_counts, yerr, model_only, residuals, residuals_err)
 
     def _plot_spectrum(self, net_counts, yerr, model_only, residuals, residuals_err):
-
         fig, subs = plt.subplots(
             2, 1, gridspec_kw={"height_ratios": [2, 1], "hspace": 0}, figsize=(14, 8)
         )
@@ -851,7 +851,9 @@ class HAL(PluginPrototype):
             bkg_renorm = list(self._nuisance_parameters.values())[0].value
 
             obs = data_analysis_bin.observation_map.as_partial()  # type: np.array
-            bkg = data_analysis_bin.background_map.as_partial() * bkg_renorm  # type: np.array
+            bkg = (
+                data_analysis_bin.background_map.as_partial() * bkg_renorm
+            )  # type: np.array
 
             this_pseudo_log_like = log_likelihood(obs, bkg, this_model_map_hpx)
 
@@ -897,21 +899,17 @@ class HAL(PluginPrototype):
         # First get expectation under the current model and store them, if we didn't do it yet
 
         if self._clone is None:
-
             n_point_sources = self._likelihood_model.get_number_of_point_sources()
             n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
             expectations = collections.OrderedDict()
 
             for bin_id in self._maptree:
-
                 data_analysis_bin = self._maptree[bin_id]
                 if bin_id not in self._active_planes:
-
                     expectations[bin_id] = None
 
                 else:
-
                     expectations[bin_id] = (
                         self._get_expectation(
                             data_analysis_bin, bin_id, n_point_sources, n_ext_sources
@@ -920,31 +918,28 @@ class HAL(PluginPrototype):
                     )
 
             if parallel_client.is_parallel_computation_active():
-
                 # Do not clone, as the parallel environment already makes clones
 
                 clone = self
 
             else:
-
                 clone = copy.deepcopy(self)
 
             self._clone = (clone, expectations)
 
         # Substitute the observation and background for each data analysis bin
         for bin_id in self._clone[0]._maptree:
-
             data_analysis_bin = self._clone[0]._maptree[bin_id]
 
             if bin_id not in self._active_planes:
-
                 continue
 
             else:
-
                 # Active plane. Generate new data
                 expectation = self._clone[1][bin_id]
-                new_data = np.random.poisson(expectation, size=(1, expectation.shape[0])).flatten()
+                new_data = np.random.poisson(
+                    expectation, size=(1, expectation.shape[0])
+                ).flatten()
 
                 # Substitute data
                 data_analysis_bin.observation_map.set_new_values(new_data)
@@ -954,23 +949,23 @@ class HAL(PluginPrototype):
         # Adjust the name of the nuisance parameter
         old_name = list(self._clone[0]._nuisance_parameters.keys())[0]
         new_name = old_name.replace(self.name, name)
-        self._clone[0]._nuisance_parameters[new_name] = self._clone[0]._nuisance_parameters.pop(
-            old_name
-        )
+        self._clone[0]._nuisance_parameters[new_name] = self._clone[
+            0
+        ]._nuisance_parameters.pop(old_name)
 
         # Recompute biases
         self._clone[0]._compute_likelihood_biases()
 
         return self._clone[0]
 
-    def _get_expectation(self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources):
-
+    def _get_expectation(
+        self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources
+    ):
         # Compute the expectation from the model
 
         this_model_map = None
 
         for pts_id in range(n_point_sources):
-
             this_conv_src = self._convolved_point_sources[pts_id]
 
             expectation_per_transit = this_conv_src.get_source_map(
@@ -979,63 +974,62 @@ class HAL(PluginPrototype):
                 psf_integration_method=self._psf_integration_method,
             )
 
-            expectation_from_this_source = expectation_per_transit * data_analysis_bin.n_transits
+            expectation_from_this_source = (
+                expectation_per_transit * data_analysis_bin.n_transits
+            )
 
             if this_model_map is None:
-
                 # First addition
 
                 this_model_map = expectation_from_this_source
 
             else:
-
                 this_model_map += expectation_from_this_source
 
         # Now process extended sources
         if n_ext_sources > 0:
-
             this_ext_model_map = None
 
             for ext_id in range(n_ext_sources):
-
                 this_conv_src = self._convolved_ext_sources[ext_id]
 
                 expectation_per_transit = this_conv_src.get_source_map(energy_bin_id)
 
                 if this_ext_model_map is None:
-
                     # First addition
 
                     this_ext_model_map = expectation_per_transit
 
                 else:
-
                     this_ext_model_map += expectation_per_transit
 
             # Now convolve with the PSF
             if this_model_map is None:
-
                 # Only extended sources
 
                 this_model_map = (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
+                    self._psf_convolutors[energy_bin_id].extended_source_image(
+                        this_ext_model_map
+                    )
                     * data_analysis_bin.n_transits
                 )
 
             else:
-
                 this_model_map += (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
+                    self._psf_convolutors[energy_bin_id].extended_source_image(
+                        this_ext_model_map
+                    )
                     * data_analysis_bin.n_transits
                 )
 
         # Now transform from the flat sky projection to HEALPiX
 
         if this_model_map is not None:
-
             # First divide for the pixel area because we need to interpolate brightness
             # this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
-            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
+            this_model_map = (
+                this_model_map / self._flat_sky_projection.project_plane_pixel_area
+            )
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](
                 this_model_map, fill_value=0.0
@@ -1045,7 +1039,6 @@ class HAL(PluginPrototype):
             this_model_map_hpx *= hp.nside2pixarea(data_analysis_bin.nside, degrees=True)
 
         else:
-
             # No sources
 
             this_model_map_hpx = 0.0
@@ -1056,7 +1049,6 @@ class HAL(PluginPrototype):
     def _represent_healpix_map(
         fig, hpx_map, longitude, latitude, xsize, resolution, smoothing_kernel_sigma
     ):
-
         proj = get_gnomonic_projection(
             fig, hpx_map, rot=(longitude, latitude, 0.0), xsize=xsize, reso=resolution
         )
@@ -1110,14 +1102,15 @@ class HAL(PluginPrototype):
         images = ["None"] * n_columns
 
         for i, plane_id in enumerate(self._active_planes):
-
             data_analysis_bin = self._maptree[plane_id]
 
             # Get the center of the projection for this plane
             this_ra, this_dec = self._roi.ra_dec_center
 
             # Make a full healpix map for a second
-            whole_map = self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
+            whole_map = self._get_model_map(
+                plane_id, n_point_sources, n_ext_sources
+            ).as_dense()
 
             # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
             longitude = ra_to_longitude(this_ra)
@@ -1126,7 +1119,9 @@ class HAL(PluginPrototype):
             latitude = this_dec
 
             # Background and excess maps
-            bkg_subtracted, _, background_map = self._get_excess(data_analysis_bin, all_maps=True)
+            bkg_subtracted, _, background_map = self._get_excess(
+                data_analysis_bin, all_maps=True
+            )
 
             # Make all the projections: model, excess, background, residuals
             proj_model = self._represent_healpix_map(
@@ -1160,7 +1155,9 @@ class HAL(PluginPrototype):
             vmax = max(np.nanmax(proj_model), np.nanmax(proj_data))
 
             # Plot model
-            images[0] = subs[i][0].imshow(proj_model, origin="lower", vmin=vmin, vmax=vmax)
+            images[0] = subs[i][0].imshow(
+                proj_model, origin="lower", vmin=vmin, vmax=vmax
+            )
             subs[i][0].set_title("model, bin {}".format(data_analysis_bin.name))
 
             # Plot data map
@@ -1185,12 +1182,12 @@ class HAL(PluginPrototype):
 
             prog_bar.update(1)
 
-        fig.set_tight_layout(True)
+        # fig.set_tight_layout(True)
+        fig.set_layout_engine("tight")
 
         return fig
 
     def _get_optimal_xsize(self, resolution):
-
         return 2.2 * self._roi.data_radius.to("deg").value / (resolution / 60.0)
 
     def display_stacked_image(self, smoothing_kernel_sigma=0.5):
@@ -1221,7 +1218,6 @@ class HAL(PluginPrototype):
         total = None
 
         for i, data_analysis_bin in enumerate(active_planes_bins):
-
             # Plot data
             background_map = data_analysis_bin.background_map.as_dense()
             this_data = data_analysis_bin.observation_map.as_dense() - background_map
@@ -1229,11 +1225,9 @@ class HAL(PluginPrototype):
             # this_data[idx] = hp.UNSEEN
 
             if i == 0:
-
                 total = this_data
 
             else:
-
                 # Sum only when there is no UNSEEN, so that the UNSEEN pixels will stay UNSEEN
                 total[~idx] += this_data[~idx]
 
@@ -1323,7 +1317,6 @@ class HAL(PluginPrototype):
             poisson_set = self.get_simulated_dataset("model map")
 
         for plane_id in self._active_planes:
-
             data_analysis_bin = self._maptree[plane_id]
 
             bkg = data_analysis_bin.background_map

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -6,13 +6,17 @@ import copy
 from builtins import range, str
 
 import astromodels
+import astropy.units as u
 import healpy as hp
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astromodels import Parameter
 from astropy.convolution import Gaussian2DKernel
 from astropy.convolution import convolve_fft as convolve
+from astropy.coordinates import Angle
+from astropy.utils.misc import isiterable
 from past.utils import old_div
 from scipy.stats import poisson
 from threeML.io.logging import setup_logger
@@ -63,6 +67,7 @@ class HAL(PluginPrototype):
         flat_sky_pixels_size=0.17,
         set_transits=None,
     ):
+
         # Store ROI
         self._roi = roi
 
@@ -77,9 +82,7 @@ class HAL(PluginPrototype):
 
         # Set up the flat-sky projection
         self.flat_sky_pixels_size = flat_sky_pixels_size
-        self._flat_sky_projection = self._roi.get_flat_sky_projection(
-            self.flat_sky_pixels_size
-        )
+        self._flat_sky_projection = self._roi.get_flat_sky_projection(self.flat_sky_pixels_size)
 
         # Read map tree (data)
         self._maptree = map_tree_factory(maptree, roi=self._roi, n_transits=n_transits)
@@ -193,6 +196,7 @@ class HAL(PluginPrototype):
 
     @psf_integration_method.setter
     def psf_integration_method(self, mode):
+
         assert mode.lower() in [
             "exact",
             "fast",
@@ -201,9 +205,8 @@ class HAL(PluginPrototype):
         self._psf_integration_method = mode.lower()
 
     def _setup_psf_convolutors(self):
-        central_response_bins = self._response.get_response_dec_bin(
-            self._roi.ra_dec_center[1]
-        )
+
+        central_response_bins = self._response.get_response_dec_bin(self._roi.ra_dec_center[1])
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
@@ -214,6 +217,7 @@ class HAL(PluginPrototype):
                 )
 
     def _compute_likelihood_biases(self):
+
         for bin_label in self._maptree:
             data_analysis_bin = self._maptree[bin_label]
 
@@ -262,6 +266,7 @@ class HAL(PluginPrototype):
 
         # Check for legal input
         if bin_id_min is not None:
+
             assert (
                 bin_id_max is not None
             ), "If you provide a minimum bin, you also need to provide a maximum bin."
@@ -279,6 +284,7 @@ class HAL(PluginPrototype):
                 self._active_planes.append(this_bin)
 
         else:
+
             assert (
                 bin_id_max is None
             ), "If you provie a maximum bin, you also need to provide a minimum bin."
@@ -288,6 +294,7 @@ class HAL(PluginPrototype):
             self._active_planes = []
 
             for this_bin in bin_list:
+
                 # if not this_bin in self._all_planes:
                 if this_bin not in self._all_planes:
                     raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
@@ -361,17 +368,21 @@ class HAL(PluginPrototype):
 
         # NOTE: ext_sources evaluate to False if empty
         if ext_sources:
+
             # We will need to convolve
 
             self._setup_psf_convolutors()
 
             for source in ext_sources:
+
                 if source.spatial_shape.n_dim == 2:
+
                     this_convolved_ext_source = ConvolvedExtendedSource2D(
                         source, self._response, self._flat_sky_projection
                     )
 
                 else:
+
                     this_convolved_ext_source = ConvolvedExtendedSource3D(
                         source, self._response, self._flat_sky_projection
                     )
@@ -441,9 +452,7 @@ class HAL(PluginPrototype):
             # each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_model_map(
-                energy_id, n_point_sources, n_ext_sources
-            ).as_partial()
+            mdl = self._get_model_map(energy_id, n_point_sources, n_ext_sources).as_partial()
 
             # select counts only from the pixels within specifid distance from
             # origin of radial profile
@@ -548,10 +557,7 @@ class HAL(PluginPrototype):
             self.set_model(model_to_subtract)
 
             model_subtract = np.array(
-                [
-                    self.get_excess_background(ra, dec, r + offset * delta_r)[3]
-                    for r in radii
-                ]
+                [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
             )
 
             temp = model_subtract[1:] - model_subtract[:-1]
@@ -571,15 +577,11 @@ class HAL(PluginPrototype):
         # them to the data later. Weight is normalized (sum of weights over
         # the bins = 1).
 
-        np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
+        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
 
-        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
-            good_planes
-        ]
+        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[good_planes]
 
-        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
-            good_planes
-        ]
+        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[good_planes]
 
         w = np.divide(total_model, total_bkg)
         weight = np.array([w / np.sum(w) for _ in radii])
@@ -633,13 +635,7 @@ class HAL(PluginPrototype):
             values for easy retrieval
         """
 
-        (
-            radii,
-            excess_model,
-            excess_data,
-            excess_error,
-            plane_ids,
-        ) = self.get_radial_profile(
+        (radii, excess_model, excess_data, excess_error, plane_ids,) = self.get_radial_profile(
             ra,
             dec,
             active_planes,
@@ -731,6 +727,7 @@ class HAL(PluginPrototype):
         yerr_high = np.zeros_like(total_counts)
 
         for i, energy_id in enumerate(self._active_planes):
+
             data_analysis_bin = self._maptree[energy_id]
 
             this_model_map_hpx = self._get_expectation(
@@ -749,6 +746,7 @@ class HAL(PluginPrototype):
             total_model[i] = this_wh_model
 
             if this_data_tot >= 50.0:
+
                 # Gaussian limit
                 # Under the null hypothesis the data are distributed as a Gaussian with mu = model
                 # and sigma = sqrt(model)
@@ -758,6 +756,7 @@ class HAL(PluginPrototype):
                 yerr_high[i] = np.sqrt(this_data_tot)
 
             else:
+
                 # Low-counts
                 # Under the null hypothesis the data are distributed as a Poisson distribution with
                 # mean = model, plot the 68% confidence interval (quantile=[0.16,1-0.16]).
@@ -781,6 +780,7 @@ class HAL(PluginPrototype):
         return self._plot_spectrum(net_counts, yerr, model_only, residuals, residuals_err)
 
     def _plot_spectrum(self, net_counts, yerr, model_only, residuals, residuals_err):
+
         fig, subs = plt.subplots(
             2, 1, gridspec_kw={"height_ratios": [2, 1], "hspace": 0}, figsize=(14, 8)
         )
@@ -851,9 +851,7 @@ class HAL(PluginPrototype):
             bkg_renorm = list(self._nuisance_parameters.values())[0].value
 
             obs = data_analysis_bin.observation_map.as_partial()  # type: np.array
-            bkg = (
-                data_analysis_bin.background_map.as_partial() * bkg_renorm
-            )  # type: np.array
+            bkg = data_analysis_bin.background_map.as_partial() * bkg_renorm  # type: np.array
 
             this_pseudo_log_like = log_likelihood(obs, bkg, this_model_map_hpx)
 
@@ -899,17 +897,21 @@ class HAL(PluginPrototype):
         # First get expectation under the current model and store them, if we didn't do it yet
 
         if self._clone is None:
+
             n_point_sources = self._likelihood_model.get_number_of_point_sources()
             n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
             expectations = collections.OrderedDict()
 
             for bin_id in self._maptree:
+
                 data_analysis_bin = self._maptree[bin_id]
                 if bin_id not in self._active_planes:
+
                     expectations[bin_id] = None
 
                 else:
+
                     expectations[bin_id] = (
                         self._get_expectation(
                             data_analysis_bin, bin_id, n_point_sources, n_ext_sources
@@ -918,28 +920,31 @@ class HAL(PluginPrototype):
                     )
 
             if parallel_client.is_parallel_computation_active():
+
                 # Do not clone, as the parallel environment already makes clones
 
                 clone = self
 
             else:
+
                 clone = copy.deepcopy(self)
 
             self._clone = (clone, expectations)
 
         # Substitute the observation and background for each data analysis bin
         for bin_id in self._clone[0]._maptree:
+
             data_analysis_bin = self._clone[0]._maptree[bin_id]
 
             if bin_id not in self._active_planes:
+
                 continue
 
             else:
+
                 # Active plane. Generate new data
                 expectation = self._clone[1][bin_id]
-                new_data = np.random.poisson(
-                    expectation, size=(1, expectation.shape[0])
-                ).flatten()
+                new_data = np.random.poisson(expectation, size=(1, expectation.shape[0])).flatten()
 
                 # Substitute data
                 data_analysis_bin.observation_map.set_new_values(new_data)
@@ -949,23 +954,23 @@ class HAL(PluginPrototype):
         # Adjust the name of the nuisance parameter
         old_name = list(self._clone[0]._nuisance_parameters.keys())[0]
         new_name = old_name.replace(self.name, name)
-        self._clone[0]._nuisance_parameters[new_name] = self._clone[
-            0
-        ]._nuisance_parameters.pop(old_name)
+        self._clone[0]._nuisance_parameters[new_name] = self._clone[0]._nuisance_parameters.pop(
+            old_name
+        )
 
         # Recompute biases
         self._clone[0]._compute_likelihood_biases()
 
         return self._clone[0]
 
-    def _get_expectation(
-        self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources
-    ):
+    def _get_expectation(self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources):
+
         # Compute the expectation from the model
 
         this_model_map = None
 
         for pts_id in range(n_point_sources):
+
             this_conv_src = self._convolved_point_sources[pts_id]
 
             expectation_per_transit = this_conv_src.get_source_map(
@@ -974,62 +979,63 @@ class HAL(PluginPrototype):
                 psf_integration_method=self._psf_integration_method,
             )
 
-            expectation_from_this_source = (
-                expectation_per_transit * data_analysis_bin.n_transits
-            )
+            expectation_from_this_source = expectation_per_transit * data_analysis_bin.n_transits
 
             if this_model_map is None:
+
                 # First addition
 
                 this_model_map = expectation_from_this_source
 
             else:
+
                 this_model_map += expectation_from_this_source
 
         # Now process extended sources
         if n_ext_sources > 0:
+
             this_ext_model_map = None
 
             for ext_id in range(n_ext_sources):
+
                 this_conv_src = self._convolved_ext_sources[ext_id]
 
                 expectation_per_transit = this_conv_src.get_source_map(energy_bin_id)
 
                 if this_ext_model_map is None:
+
                     # First addition
 
                     this_ext_model_map = expectation_per_transit
 
                 else:
+
                     this_ext_model_map += expectation_per_transit
 
             # Now convolve with the PSF
             if this_model_map is None:
+
                 # Only extended sources
 
                 this_model_map = (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(
-                        this_ext_model_map
-                    )
+                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
                     * data_analysis_bin.n_transits
                 )
 
             else:
+
                 this_model_map += (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(
-                        this_ext_model_map
-                    )
+                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
                     * data_analysis_bin.n_transits
                 )
 
         # Now transform from the flat sky projection to HEALPiX
 
         if this_model_map is not None:
+
             # First divide for the pixel area because we need to interpolate brightness
             # this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
-            this_model_map = (
-                this_model_map / self._flat_sky_projection.project_plane_pixel_area
-            )
+            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](
                 this_model_map, fill_value=0.0
@@ -1039,6 +1045,7 @@ class HAL(PluginPrototype):
             this_model_map_hpx *= hp.nside2pixarea(data_analysis_bin.nside, degrees=True)
 
         else:
+
             # No sources
 
             this_model_map_hpx = 0.0
@@ -1049,6 +1056,7 @@ class HAL(PluginPrototype):
     def _represent_healpix_map(
         fig, hpx_map, longitude, latitude, xsize, resolution, smoothing_kernel_sigma
     ):
+
         proj = get_gnomonic_projection(
             fig, hpx_map, rot=(longitude, latitude, 0.0), xsize=xsize, reso=resolution
         )
@@ -1102,15 +1110,14 @@ class HAL(PluginPrototype):
         images = ["None"] * n_columns
 
         for i, plane_id in enumerate(self._active_planes):
+
             data_analysis_bin = self._maptree[plane_id]
 
             # Get the center of the projection for this plane
             this_ra, this_dec = self._roi.ra_dec_center
 
             # Make a full healpix map for a second
-            whole_map = self._get_model_map(
-                plane_id, n_point_sources, n_ext_sources
-            ).as_dense()
+            whole_map = self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
 
             # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
             longitude = ra_to_longitude(this_ra)
@@ -1119,9 +1126,7 @@ class HAL(PluginPrototype):
             latitude = this_dec
 
             # Background and excess maps
-            bkg_subtracted, _, background_map = self._get_excess(
-                data_analysis_bin, all_maps=True
-            )
+            bkg_subtracted, _, background_map = self._get_excess(data_analysis_bin, all_maps=True)
 
             # Make all the projections: model, excess, background, residuals
             proj_model = self._represent_healpix_map(
@@ -1155,9 +1160,7 @@ class HAL(PluginPrototype):
             vmax = max(np.nanmax(proj_model), np.nanmax(proj_data))
 
             # Plot model
-            images[0] = subs[i][0].imshow(
-                proj_model, origin="lower", vmin=vmin, vmax=vmax
-            )
+            images[0] = subs[i][0].imshow(proj_model, origin="lower", vmin=vmin, vmax=vmax)
             subs[i][0].set_title("model, bin {}".format(data_analysis_bin.name))
 
             # Plot data map
@@ -1182,12 +1185,12 @@ class HAL(PluginPrototype):
 
             prog_bar.update(1)
 
-        # fig.set_tight_layout(True)
-        fig.set_layout_engine("tight")
+        fig.set_tight_layout(True)
 
         return fig
 
     def _get_optimal_xsize(self, resolution):
+
         return 2.2 * self._roi.data_radius.to("deg").value / (resolution / 60.0)
 
     def display_stacked_image(self, smoothing_kernel_sigma=0.5):
@@ -1218,6 +1221,7 @@ class HAL(PluginPrototype):
         total = None
 
         for i, data_analysis_bin in enumerate(active_planes_bins):
+
             # Plot data
             background_map = data_analysis_bin.background_map.as_dense()
             this_data = data_analysis_bin.observation_map.as_dense() - background_map
@@ -1225,9 +1229,11 @@ class HAL(PluginPrototype):
             # this_data[idx] = hp.UNSEEN
 
             if i == 0:
+
                 total = this_data
 
             else:
+
                 # Sum only when there is no UNSEEN, so that the UNSEEN pixels will stay UNSEEN
                 total[~idx] += this_data[~idx]
 
@@ -1317,6 +1323,7 @@ class HAL(PluginPrototype):
             poisson_set = self.get_simulated_dataset("model map")
 
         for plane_id in self._active_planes:
+
             data_analysis_bin = self._maptree[plane_id]
 
             bkg = data_analysis_bin.background_map

--- a/hawc_hal/HAL.py
+++ b/hawc_hal/HAL.py
@@ -4,19 +4,16 @@ import collections
 import contextlib
 import copy
 from builtins import range, str
+from typing import Union
 
 import astromodels
-import astropy.units as u
 import healpy as hp
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astromodels import Parameter
 from astropy.convolution import Gaussian2DKernel
 from astropy.convolution import convolve_fft as convolve
-from astropy.coordinates import Angle
-from astropy.utils.misc import isiterable
 from past.utils import old_div
 from scipy.stats import poisson
 from threeML.io.logging import setup_logger
@@ -64,12 +61,13 @@ class HAL(PluginPrototype):
         maptree,
         response_file,
         roi,
-        flat_sky_pixels_size=0.17,
+        flat_sky_pixels_size: float = 0.17,
+        n_workers: int = 1,
         set_transits=None,
     ):
-
         # Store ROI
         self._roi = roi
+        self._n_workers = n_workers
 
         # optionally specify n_transits
         if set_transits is not None:
@@ -82,13 +80,19 @@ class HAL(PluginPrototype):
 
         # Set up the flat-sky projection
         self.flat_sky_pixels_size = flat_sky_pixels_size
-        self._flat_sky_projection = self._roi.get_flat_sky_projection(self.flat_sky_pixels_size)
+        self._flat_sky_projection = self._roi.get_flat_sky_projection(
+            self.flat_sky_pixels_size
+        )
 
         # Read map tree (data)
-        self._maptree = map_tree_factory(maptree, roi=self._roi, n_transits=n_transits)
+        self._maptree = map_tree_factory(
+            maptree, roi=self._roi, n_transits=n_transits, n_workers=self._n_workers
+        )
 
         # Read detector response_file
-        self._response = hawc_response_factory(response_file)
+        self._response = hawc_response_factory(
+            response_file_name=response_file, n_workers=self._n_workers
+        )
 
         # Use a renormalization of the background as nuisance parameter
         # NOTE: it is fixed to 1.0 unless the user explicitly sets it free (experimental)
@@ -107,7 +111,9 @@ class HAL(PluginPrototype):
 
         # Instance parent class
 
-        super(HAL, self).__init__(name, self._nuisance_parameters)
+        # super(HAL, self).__init__(name, self._nuisance_parameters)
+        # python3 new way of doing things
+        super().__init__(name, self._nuisance_parameters)
 
         self._likelihood_model = None
 
@@ -196,7 +202,6 @@ class HAL(PluginPrototype):
 
     @psf_integration_method.setter
     def psf_integration_method(self, mode):
-
         assert mode.lower() in [
             "exact",
             "fast",
@@ -205,8 +210,9 @@ class HAL(PluginPrototype):
         self._psf_integration_method = mode.lower()
 
     def _setup_psf_convolutors(self):
-
-        central_response_bins = self._response.get_response_dec_bin(self._roi.ra_dec_center[1])
+        central_response_bins = self._response.get_response_dec_bin(
+            self._roi.ra_dec_center[1]
+        )
 
         self._psf_convolutors = collections.OrderedDict()
         for bin_id in central_response_bins:
@@ -217,7 +223,6 @@ class HAL(PluginPrototype):
                 )
 
     def _compute_likelihood_biases(self):
-
         for bin_label in self._maptree:
             data_analysis_bin = self._maptree[bin_label]
 
@@ -266,7 +271,6 @@ class HAL(PluginPrototype):
 
         # Check for legal input
         if bin_id_min is not None:
-
             assert (
                 bin_id_max is not None
             ), "If you provide a minimum bin, you also need to provide a maximum bin."
@@ -279,12 +283,13 @@ class HAL(PluginPrototype):
             for this_bin in range(bin_id_min, bin_id_max + 1):
                 this_bin = str(this_bin)
                 if this_bin not in self._all_planes:
-                    raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
+                    raise ValueError(
+                        f"Bin {this_bin} is not contained in this maptree."
+                    )
 
                 self._active_planes.append(this_bin)
 
         else:
-
             assert (
                 bin_id_max is None
             ), "If you provie a maximum bin, you also need to provide a minimum bin."
@@ -294,10 +299,11 @@ class HAL(PluginPrototype):
             self._active_planes = []
 
             for this_bin in bin_list:
-
                 # if not this_bin in self._all_planes:
                 if this_bin not in self._all_planes:
-                    raise ValueError(f"Bin {this_bin} is not contained in this maptree.")
+                    raise ValueError(
+                        f"Bin {this_bin} is not contained in this maptree."
+                    )
 
                 self._active_planes.append(this_bin)
 
@@ -368,21 +374,17 @@ class HAL(PluginPrototype):
 
         # NOTE: ext_sources evaluate to False if empty
         if ext_sources:
-
             # We will need to convolve
 
             self._setup_psf_convolutors()
 
             for source in ext_sources:
-
                 if source.spatial_shape.n_dim == 2:
-
                     this_convolved_ext_source = ConvolvedExtendedSource2D(
                         source, self._response, self._flat_sky_projection
                     )
 
                 else:
-
                     this_convolved_ext_source = ConvolvedExtendedSource3D(
                         source, self._response, self._flat_sky_projection
                     )
@@ -452,7 +454,9 @@ class HAL(PluginPrototype):
             # each radial bin
             data = data_analysis_bin.observation_map.as_partial()
             bkg = data_analysis_bin.background_map.as_partial()
-            mdl = self._get_model_map(energy_id, n_point_sources, n_ext_sources).as_partial()
+            mdl = self._get_model_map(
+                energy_id, n_point_sources, n_ext_sources
+            ).as_partial()
 
             # select counts only from the pixels within specifid distance from
             # origin of radial profile
@@ -519,7 +523,10 @@ class HAL(PluginPrototype):
         # The area of each ring is then given by the difference between two
         # subsequent circe areas.
         area = np.array(
-            [self.get_excess_background(ra, dec, r + offset * delta_r)[0] for r in radii]
+            [
+                self.get_excess_background(ra, dec, r + offset * delta_r)[0]
+                for r in radii
+            ]
         )
 
         temp = area[1:] - area[:-1]
@@ -527,7 +534,10 @@ class HAL(PluginPrototype):
 
         # signals
         signal = np.array(
-            [self.get_excess_background(ra, dec, r + offset * delta_r)[1] for r in radii]
+            [
+                self.get_excess_background(ra, dec, r + offset * delta_r)[1]
+                for r in radii
+            ]
         )
 
         temp = signal[1:] - signal[:-1]
@@ -535,7 +545,10 @@ class HAL(PluginPrototype):
 
         # backgrounds
         bkg = np.array(
-            [self.get_excess_background(ra, dec, r + offset * delta_r)[2] for r in radii]
+            [
+                self.get_excess_background(ra, dec, r + offset * delta_r)[2]
+                for r in radii
+            ]
         )
 
         temp = bkg[1:] - bkg[:-1]
@@ -546,7 +559,10 @@ class HAL(PluginPrototype):
         # model
         # convert 'top hat' excess into 'ring' excesses.
         model = np.array(
-            [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
+            [
+                self.get_excess_background(ra, dec, r + offset * delta_r)[3]
+                for r in radii
+            ]
         )
 
         temp = model[1:] - model[:-1]
@@ -557,7 +573,10 @@ class HAL(PluginPrototype):
             self.set_model(model_to_subtract)
 
             model_subtract = np.array(
-                [self.get_excess_background(ra, dec, r + offset * delta_r)[3] for r in radii]
+                [
+                    self.get_excess_background(ra, dec, r + offset * delta_r)[3]
+                    for r in radii
+                ]
             )
 
             temp = model_subtract[1:] - model_subtract[:-1]
@@ -577,11 +596,15 @@ class HAL(PluginPrototype):
         # them to the data later. Weight is normalized (sum of weights over
         # the bins = 1).
 
-        total_excess = np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
+        np.array(self.get_excess_background(ra, dec, max_radius)[1])[good_planes]
 
-        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[good_planes]
+        total_bkg = np.array(self.get_excess_background(ra, dec, max_radius)[2])[
+            good_planes
+        ]
 
-        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[good_planes]
+        total_model = np.array(self.get_excess_background(ra, dec, max_radius)[3])[
+            good_planes
+        ]
 
         w = np.divide(total_model, total_bkg)
         weight = np.array([w / np.sum(w) for _ in radii])
@@ -635,7 +658,13 @@ class HAL(PluginPrototype):
             values for easy retrieval
         """
 
-        (radii, excess_model, excess_data, excess_error, plane_ids,) = self.get_radial_profile(
+        (
+            radii,
+            excess_model,
+            excess_data,
+            excess_error,
+            plane_ids,
+        ) = self.get_radial_profile(
             ra,
             dec,
             active_planes,
@@ -667,7 +696,9 @@ class HAL(PluginPrototype):
 
         plt.plot(radii, excess_model, color="red", label="Model")
 
-        plt.legend(bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1, fontsize=16)
+        plt.legend(
+            bbox_to_anchor=(1.0, 1.0), loc="upper right", numpoints=1, fontsize=16
+        )
         plt.axhline(0, color="deepskyblue", linestyle="--")
 
         x_limits = [0, max_radius]
@@ -727,7 +758,6 @@ class HAL(PluginPrototype):
         yerr_high = np.zeros_like(total_counts)
 
         for i, energy_id in enumerate(self._active_planes):
-
             data_analysis_bin = self._maptree[energy_id]
 
             this_model_map_hpx = self._get_expectation(
@@ -746,7 +776,6 @@ class HAL(PluginPrototype):
             total_model[i] = this_wh_model
 
             if this_data_tot >= 50.0:
-
                 # Gaussian limit
                 # Under the null hypothesis the data are distributed as a Gaussian with mu = model
                 # and sigma = sqrt(model)
@@ -756,7 +785,6 @@ class HAL(PluginPrototype):
                 yerr_high[i] = np.sqrt(this_data_tot)
 
             else:
-
                 # Low-counts
                 # Under the null hypothesis the data are distributed as a Poisson distribution with
                 # mean = model, plot the 68% confidence interval (quantile=[0.16,1-0.16]).
@@ -777,10 +805,11 @@ class HAL(PluginPrototype):
 
         yerr = [yerr_high, yerr_low]
 
-        return self._plot_spectrum(net_counts, yerr, model_only, residuals, residuals_err)
+        return self._plot_spectrum(
+            net_counts, yerr, model_only, residuals, residuals_err
+        )
 
     def _plot_spectrum(self, net_counts, yerr, model_only, residuals, residuals_err):
-
         fig, subs = plt.subplots(
             2, 1, gridspec_kw={"height_ratios": [2, 1], "hspace": 0}, figsize=(14, 8)
         )
@@ -819,11 +848,22 @@ class HAL(PluginPrototype):
 
         return fig
 
+    @property
+    def number_of_workers(self):
+        """
+        Get or set the number of workers to use for the parallelization of the computation of the likelihood.
+        """
+        return self._n_workers
+
     def get_log_like(self, individual_bins=False, return_null=False):
         """
         Return the value of the log-likelihood with the current values for the
         parameters
         """
+        # NOTE: multi-processing definition done a as global variable
+        # done this way to avoid pickling issues
+        # global process_bin
+
         if return_null is True:
             n_point_sources = 0
             n_ext_sources = 0
@@ -838,6 +878,7 @@ class HAL(PluginPrototype):
             ), "The number of sources has changed. Please re-assign the model to the plugin."
 
         # This will hold the total log-likelihood
+
         total_log_like = 0
         log_like_per_bin = {}
 
@@ -850,8 +891,8 @@ class HAL(PluginPrototype):
             # Now compare with observation
             bkg_renorm = list(self._nuisance_parameters.values())[0].value
 
-            obs = data_analysis_bin.observation_map.as_partial()  # type: np.array
-            bkg = data_analysis_bin.background_map.as_partial() * bkg_renorm  # type: np.array
+            obs: np.ndarray = data_analysis_bin.observation_map.as_partial()
+            bkg: np.ndarray = data_analysis_bin.background_map.as_partial() * bkg_renorm
 
             this_pseudo_log_like = log_likelihood(obs, bkg, this_model_map_hpx)
 
@@ -867,12 +908,13 @@ class HAL(PluginPrototype):
                     - self._log_factorials[bin_id]
                     - self._saturated_model_like_per_maptree[bin_id]
                 )
+
         if individual_bins is True:
             for k in log_like_per_bin:
                 log_like_per_bin[k] /= total_log_like
             return total_log_like, log_like_per_bin
-        else:
-            return total_log_like
+        # else:
+        return total_log_like
 
     def write(self, response_file_name, map_tree_file_name):
         """
@@ -897,21 +939,17 @@ class HAL(PluginPrototype):
         # First get expectation under the current model and store them, if we didn't do it yet
 
         if self._clone is None:
-
             n_point_sources = self._likelihood_model.get_number_of_point_sources()
             n_ext_sources = self._likelihood_model.get_number_of_extended_sources()
 
             expectations = collections.OrderedDict()
 
             for bin_id in self._maptree:
-
                 data_analysis_bin = self._maptree[bin_id]
                 if bin_id not in self._active_planes:
-
                     expectations[bin_id] = None
 
                 else:
-
                     expectations[bin_id] = (
                         self._get_expectation(
                             data_analysis_bin, bin_id, n_point_sources, n_ext_sources
@@ -920,31 +958,28 @@ class HAL(PluginPrototype):
                     )
 
             if parallel_client.is_parallel_computation_active():
-
                 # Do not clone, as the parallel environment already makes clones
 
                 clone = self
 
             else:
-
                 clone = copy.deepcopy(self)
 
             self._clone = (clone, expectations)
 
         # Substitute the observation and background for each data analysis bin
         for bin_id in self._clone[0]._maptree:
-
             data_analysis_bin = self._clone[0]._maptree[bin_id]
 
             if bin_id not in self._active_planes:
-
                 continue
 
             else:
-
                 # Active plane. Generate new data
                 expectation = self._clone[1][bin_id]
-                new_data = np.random.poisson(expectation, size=(1, expectation.shape[0])).flatten()
+                new_data = np.random.poisson(
+                    expectation, size=(1, expectation.shape[0])
+                ).flatten()
 
                 # Substitute data
                 data_analysis_bin.observation_map.set_new_values(new_data)
@@ -954,98 +989,131 @@ class HAL(PluginPrototype):
         # Adjust the name of the nuisance parameter
         old_name = list(self._clone[0]._nuisance_parameters.keys())[0]
         new_name = old_name.replace(self.name, name)
-        self._clone[0]._nuisance_parameters[new_name] = self._clone[0]._nuisance_parameters.pop(
-            old_name
-        )
+        self._clone[0]._nuisance_parameters[new_name] = self._clone[
+            0
+        ]._nuisance_parameters.pop(old_name)
 
         # Recompute biases
         self._clone[0]._compute_likelihood_biases()
 
         return self._clone[0]
 
-    def _get_expectation(self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources):
+    def _compute_expectation(
+        self,
+        data_analysis_bin: DataAnalysisBin,
+        energy_bin_id: str,
+        convolved_source: Union[
+            ConvolvedPointSource, ConvolvedExtendedSource2D, ConvolvedExtendedSource3D
+        ],
+        this_model_map: Union[float, None],
+    ):
+        expectation_per_transit = convolved_source.get_source_map(
+            energy_bin_id,
+            tag=None,
+            psf_integration_method=self._psf_integration_method,
+        )
 
+        expectation_from_this_source = (
+            expectation_per_transit * data_analysis_bin.n_transits
+        )
+
+        if this_model_map is None:
+            # First addition
+            #
+            this_model_map = expectation_from_this_source
+
+        else:
+            this_model_map += expectation_from_this_source
+
+        return expectation_from_this_source
+
+    def _get_expectation(
+        self, data_analysis_bin, energy_bin_id, n_point_sources, n_ext_sources
+    ):
         # Compute the expectation from the model
 
         this_model_map = None
 
         for pts_id in range(n_point_sources):
+            this_conv_pnt_src: ConvolvedPointSource = self._convolved_point_sources[
+                pts_id
+            ]
 
-            this_conv_src = self._convolved_point_sources[pts_id]
-
-            expectation_per_transit = this_conv_src.get_source_map(
+            expectation_per_transit = this_conv_pnt_src.get_source_map(
                 energy_bin_id,
                 tag=None,
                 psf_integration_method=self._psf_integration_method,
             )
 
-            expectation_from_this_source = expectation_per_transit * data_analysis_bin.n_transits
+            expectation_from_this_source = (
+                expectation_per_transit * data_analysis_bin.n_transits
+            )
 
             if this_model_map is None:
-
                 # First addition
 
                 this_model_map = expectation_from_this_source
 
             else:
-
                 this_model_map += expectation_from_this_source
 
         # Now process extended sources
         if n_ext_sources > 0:
-
             this_ext_model_map = None
 
             for ext_id in range(n_ext_sources):
-
-                this_conv_src = self._convolved_ext_sources[ext_id]
+                this_conv_src: Union[
+                    ConvolvedExtendedSource2D, ConvolvedExtendedSource3D
+                ] = self._convolved_ext_sources[ext_id]
 
                 expectation_per_transit = this_conv_src.get_source_map(energy_bin_id)
 
                 if this_ext_model_map is None:
-
                     # First addition
 
                     this_ext_model_map = expectation_per_transit
 
                 else:
-
                     this_ext_model_map += expectation_per_transit
 
             # Now convolve with the PSF
             if this_model_map is None:
-
                 # Only extended sources
 
                 this_model_map = (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
+                    self._psf_convolutors[energy_bin_id].extended_source_image(
+                        this_ext_model_map
+                    )
                     * data_analysis_bin.n_transits
                 )
 
             else:
-
                 this_model_map += (
-                    self._psf_convolutors[energy_bin_id].extended_source_image(this_ext_model_map)
+                    self._psf_convolutors[energy_bin_id].extended_source_image(
+                        this_ext_model_map
+                    )
                     * data_analysis_bin.n_transits
                 )
 
         # Now transform from the flat sky projection to HEALPiX
 
         if this_model_map is not None:
-
             # First divide for the pixel area because we need to interpolate brightness
             # this_model_map = old_div(this_model_map, self._flat_sky_projection.project_plane_pixel_area)
-            this_model_map = this_model_map / self._flat_sky_projection.project_plane_pixel_area
+            this_model_map = (
+                this_model_map / self._flat_sky_projection.project_plane_pixel_area
+            )
 
             this_model_map_hpx = self._flat_sky_to_healpix_transform[energy_bin_id](
                 this_model_map, fill_value=0.0
             )
 
             # Now multiply by the pixel area of the new map to go back to flux
-            this_model_map_hpx *= hp.nside2pixarea(data_analysis_bin.nside, degrees=True)
+            this_model_map_hpx *= hp.nside2pixarea(
+                data_analysis_bin.nside, degrees=True
+            )
 
         else:
-
             # No sources
 
             this_model_map_hpx = 0.0
@@ -1056,7 +1124,6 @@ class HAL(PluginPrototype):
     def _represent_healpix_map(
         fig, hpx_map, longitude, latitude, xsize, resolution, smoothing_kernel_sigma
     ):
-
         proj = get_gnomonic_projection(
             fig, hpx_map, rot=(longitude, latitude, 0.0), xsize=xsize, reso=resolution
         )
@@ -1110,14 +1177,15 @@ class HAL(PluginPrototype):
         images = ["None"] * n_columns
 
         for i, plane_id in enumerate(self._active_planes):
-
             data_analysis_bin = self._maptree[plane_id]
 
             # Get the center of the projection for this plane
             this_ra, this_dec = self._roi.ra_dec_center
 
             # Make a full healpix map for a second
-            whole_map = self._get_model_map(plane_id, n_point_sources, n_ext_sources).as_dense()
+            whole_map = self._get_model_map(
+                plane_id, n_point_sources, n_ext_sources
+            ).as_dense()
 
             # Healpix uses longitude between -180 and 180, while R.A. is between 0 and 360. We need to fix that:
             longitude = ra_to_longitude(this_ra)
@@ -1126,7 +1194,9 @@ class HAL(PluginPrototype):
             latitude = this_dec
 
             # Background and excess maps
-            bkg_subtracted, _, background_map = self._get_excess(data_analysis_bin, all_maps=True)
+            bkg_subtracted, _, background_map = self._get_excess(
+                data_analysis_bin, all_maps=True
+            )
 
             # Make all the projections: model, excess, background, residuals
             proj_model = self._represent_healpix_map(
@@ -1160,11 +1230,15 @@ class HAL(PluginPrototype):
             vmax = max(np.nanmax(proj_model), np.nanmax(proj_data))
 
             # Plot model
-            images[0] = subs[i][0].imshow(proj_model, origin="lower", vmin=vmin, vmax=vmax)
+            images[0] = subs[i][0].imshow(
+                proj_model, origin="lower", vmin=vmin, vmax=vmax
+            )
             subs[i][0].set_title("model, bin {}".format(data_analysis_bin.name))
 
             # Plot data map
-            images[1] = subs[i][1].imshow(proj_data, origin="lower", vmin=vmin, vmax=vmax)
+            images[1] = subs[i][1].imshow(
+                proj_data, origin="lower", vmin=vmin, vmax=vmax
+            )
             subs[i][1].set_title("excess, bin {}".format(data_analysis_bin.name))
 
             # Plot background map.
@@ -1185,12 +1259,12 @@ class HAL(PluginPrototype):
 
             prog_bar.update(1)
 
-        fig.set_tight_layout(True)
+        # fig.set_tight_layout(True)
+        fig.set_layout_engine("tight")
 
         return fig
 
     def _get_optimal_xsize(self, resolution):
-
         return 2.2 * self._roi.data_radius.to("deg").value / (resolution / 60.0)
 
     def display_stacked_image(self, smoothing_kernel_sigma=0.5):
@@ -1221,7 +1295,6 @@ class HAL(PluginPrototype):
         total = None
 
         for i, data_analysis_bin in enumerate(active_planes_bins):
-
             # Plot data
             background_map = data_analysis_bin.background_map.as_dense()
             this_data = data_analysis_bin.observation_map.as_dense() - background_map
@@ -1229,11 +1302,9 @@ class HAL(PluginPrototype):
             # this_data[idx] = hp.UNSEEN
 
             if i == 0:
-
                 total = this_data
 
             else:
-
                 # Sum only when there is no UNSEEN, so that the UNSEEN pixels will stay UNSEEN
                 total[~idx] += this_data[~idx]
 
@@ -1287,7 +1358,9 @@ class HAL(PluginPrototype):
             raise ValueError(f"{plane_id} not a plane in the current model")
 
         model_map = SparseHealpix(
-            self._get_expectation(self._maptree[plane_id], plane_id, n_pt_src, n_ext_src),
+            self._get_expectation(
+                self._maptree[plane_id], plane_id, n_pt_src, n_ext_src
+            ),
             self._active_pixels[plane_id],
             self._maptree[plane_id].observation_map.nside,
         )
@@ -1323,7 +1396,6 @@ class HAL(PluginPrototype):
             poisson_set = self.get_simulated_dataset("model map")
 
         for plane_id in self._active_planes:
-
             data_analysis_bin = self._maptree[plane_id]
 
             bkg = data_analysis_bin.background_map
@@ -1361,13 +1433,17 @@ class HAL(PluginPrototype):
         if return_map:
             return new_map_tree
 
-    def write_model_map(self, file_name, poisson_fluctuate=False, test_return_map=False):
+    def write_model_map(
+        self, file_name, poisson_fluctuate=False, test_return_map=False
+    ):
         """
         This function writes the model map to a file.
         The interface is based off of HAWCLike for consistency
         """
         if test_return_map:
-            log.warning("test_return_map=True should only be used for testing purposes!")
+            log.warning(
+                "test_return_map=True should only be used for testing purposes!"
+            )
         return self._write_a_map(file_name, "model", poisson_fluctuate, test_return_map)
 
     def write_residual_map(self, file_name, test_return_map=False):
@@ -1376,5 +1452,7 @@ class HAL(PluginPrototype):
         The interface is based off of HAWCLike for consistency
         """
         if test_return_map:
-            log.warning("test_return_map=True should only be used for testing purposes!")
+            log.warning(
+                "test_return_map=True should only be used for testing purposes!"
+            )
         return self._write_a_map(file_name, "residual", False, test_return_map)

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -100,26 +100,21 @@ def get_array_from_file(
     hpx_map: NDArray[np.float64],
     roi: Optional[HealpixConeROI | HealpixMapROI] = None,
 ) -> tuple[str, NDArray[np.float64]]:
-    """Load the signal array from a ROOT maptree file
+    """Load the signal array from a ROOT maptree
 
-    Parameters
-    ----------
-    binning_scheme : str
-        prefix string that handles legacy naming schemes
-    bin_id : str
-        Analysis bin name from the maptree file
-    map_infile : uproot.ReadOnlyDirectory
-        Uproot object that handles the reading of the maptree file
-    hpx_map : NDArray[np.float64]
-        Healpix map array that specifies the active ROI from the active pixels
-    roi : Optional[HealpixConeROI  |  HealpixMapROI], optional
-        ROI object specifying whether there is an active ROI if None,
-        then the whole sky is loaded, by default None
-
-    Returns
-    -------
-    tuple[str, NDArray[np.float64]]
-        Returns the active analysis bin with its corresponding signal array
+    :param legacy_convention: True if there is a zero prefix in the analysis bin name
+    :type legacy_convention: bool
+    :param bin_id: Analysis bin from the maptree file
+    :type bin_id: str
+    :param map_infile: Uproot object that handles the reading of the maptree file
+    :type map_infile: uproot.ReadOnlyDirectory
+    :param hpx_map: Healpix map array that specifies the active pixels within the ROI
+    :type hpx_map: NDArray[np.float64]
+    :param roi: ROI instance specyfing the region of interest only load a partial
+    segment of the map. If set to None, it loads the full sky map (more memory intensive)
+    :type roi: Optional[HealpixConeROI | HealpixMapROI], optional
+    :return: Returns teh active analysis bin with its corresponding signal array.
+    :rtype: tuple[str, NDArray[np.float64]]
     """
 
     current_bin_id = bin_id.zfill(2) if legacy_convention else bin_id
@@ -142,24 +137,20 @@ def get_bkg_array_from_file(
 ) -> tuple[str, NDArray[np.float64]]:
     """Load the background array from a ROOT maptree file
 
-    Parameters
-    ----------
-    binning_scheme : str
-        prefix string that handles legacy naming schemes
-    bin_id : str
-        Analysis bin name from the maptree file
-    map_infile : uproot.ReadOnlyDirectory
-        Uproot object that handles the reading of the maptree file
-    hpx_map : NDArray[np.float64]
-        Healpix map array that specifies the active ROI from the active pixels
-    roi : Optional[HealpixConeROI  |  HealpixMapROI], optional
-        ROI object specifying whether there is an active ROI if None,
-        then the whole sky is loaded, by default None
-
-    Returns
-    -------
-    tuple[str, NDArray[np.float64]]
-        Returns the active analysis bin with its corresponding background array
+    :param legacy_convention: boolean to check if there is a zero prefix
+    in the analysis bin name
+    :type legacy_convention: bool
+    :param bin_id: Analysis bin from the maptree file
+    :type bin_id: str
+    :param map_infile: uproot.ReadOnlyDirectory object that handles the
+    reading of the maptree file
+    :type map_infile: uproot.ReadOnlyDirectory
+    :param hpx_map: Healpix map array that specifies the active pixels within the ROI
+    :type hpx_map: NDArray[np.float64]
+    :param roi: ROI object specifying whether there is an active ROI if None,
+    then the whole sky is loaded, by default None
+    :type roi: Optional[HealpixConeROI | HealpixMapROI], optional
+    :return: Returns the active analysis bin with its corresponding background array
     """
     current_bin_id = bin_id.zfill(2) if legacy_convention else bin_id
     if roi is not None:
@@ -178,30 +169,19 @@ def from_root_file(
     n_workers: int,
     scheme: int = 0,
 ):
-    """Create a Maptree object from a ROOT file. Do not use this derectly, use map_tree_factory instead.
+    """Create a Maptree object from a ROOT file.
+    Do not use this directly, use the maptree_factory method instead.
 
-    Parameters
-    ----------
-    map_tree_file : Path
-        Mapree ROOT file
-    roi : Union[HealpixConeROI, HealpixMapROI]
-        Region of interest set with either HealpixConeROI or HealpixMapROI
-    transits : float
-        Manual specification of the number of transits
-    n_workers : int
-        Number of workers used for multiprocessing
-    scheme : int, optional
-        RING or NESTED HEALPix scheme (default RING:0), by default 0
-
-    Returns
-    -------
-    tuple[dic[str,DataAnalysisBin], float] :
-        Returns the analysis bin id and a DataAnalysisBin object
-
-    Raises
-    ------
-    IOError
-        This will be raised if the file does not exist or is corrupted
+    :param map_tree_file: Maptree ROOT file
+    :param roi:  User defined region of interest (ROI)
+    :param transits: Number of transits specified within maptree.
+    If not specified assume the maximum number of transits for all binss.
+    :param n_workers: Numbrer of processes used for parallel reading of ROOT files
+    :param scheme: RING or NESTED Healpix scheme (default RING:0), by default 0
+    :raises IOError: Raised if file does not exist or is corrupted
+    :return: Return dictionary with DataAnalysis objects for the active bins and
+    the number of transits
+    :rtype: tuple[dict[str, DataAnalysisBin], float]
     """
 
     # from ..root_handler import open_ROOT_file, root_numpy, tree_to_ndarray

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import collections
-from builtins import range, str
+from builtins import str
 from pathlib import Path
 
 import healpy as hp
@@ -113,7 +113,7 @@ def from_root_file(
         #     n_durations
         # ), "Cannot use a higher value than that of maptree."
 
-        n_bins: int = data_bins_labels.shape[0]
+        data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
         nside_bkg: int = hp.pixelfunc.npix2nside(npix_bkg)
 
@@ -136,12 +136,13 @@ def from_root_file(
                 nside_cnt, system="equatorial", ordering="RING"
             )
 
-            for pix_id in active_pixels:
-                healpix_map_active[pix_id] = 1.0
+            healpix_map_active[active_pixels] = 1
+            # for pix_id in active_pixels:
+            # healpix_map_active[pix_id] = 1.0
 
-        for i in range(n_bins):
-            name = data_bins_labels[i]
-
+        # for i in range(n_bins):
+        # name = data_bins_labels[i]
+        for name in data_bins_labels:
             try:
                 data_tree_prefix = f"nHit{name}/data/count"
                 bkg_tree_prefix = f"nHit{name}/bkg/count"

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import collections
-from builtins import str
+from builtins import range, str
 from pathlib import Path
 
 import healpy as hp
@@ -136,13 +136,12 @@ def from_root_file(
                 nside_cnt, system="equatorial", ordering="RING"
             )
 
-            healpix_map_active[active_pixels] = 1
-            # for pix_id in active_pixels:
-            # healpix_map_active[pix_id] = 1.0
+            for pix_id in active_pixels:
+                healpix_map_active[pix_id] = 1.0
 
-        # for i in range(n_bins):
-        # name = data_bins_labels[i]
-        for name in data_bins_labels:
+        for i in range(n_bins):
+            name = data_bins_labels[i]
+
             try:
                 data_tree_prefix = f"nHit{name}/data/count"
                 bkg_tree_prefix = f"nHit{name}/bkg/count"
@@ -161,12 +160,8 @@ def from_root_file(
                 data_tree_prefix = f"nHit0{name}/data/count"
                 bkg_tree_prefix = f"nHit0{name}/bkg/count"
 
-                counts = map_infile[data_tree_prefix].array().to_numpy() * (
-                    n_transits / max(n_durations)
-                )
-                bkg = map_infile[bkg_tree_prefix].array().to_numpy() * (
-                    n_transits / max(n_durations)
-                )
+                counts = map_infile[data_tree_prefix].array().to_numpy()
+                bkg = map_infile[bkg_tree_prefix].array().to_numpy()
 
             # Read only elements within the ROI
             if roi is not None:

--- a/hawc_hal/maptree/from_root_file.py
+++ b/hawc_hal/maptree/from_root_file.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import collections
-from builtins import str
+from builtins import range, str
 from pathlib import Path
 
 import healpy as hp
@@ -113,7 +113,7 @@ def from_root_file(
         #     n_durations
         # ), "Cannot use a higher value than that of maptree."
 
-        data_bins_labels.shape[0]
+        n_bins: int = data_bins_labels.shape[0]
         nside_cnt: int = hp.pixelfunc.npix2nside(npix_cnt)
         nside_bkg: int = hp.pixelfunc.npix2nside(npix_bkg)
 
@@ -136,13 +136,12 @@ def from_root_file(
                 nside_cnt, system="equatorial", ordering="RING"
             )
 
-            healpix_map_active[active_pixels] = 1
-            # for pix_id in active_pixels:
-            # healpix_map_active[pix_id] = 1.0
+            for pix_id in active_pixels:
+                healpix_map_active[pix_id] = 1.0
 
-        # for i in range(n_bins):
-        # name = data_bins_labels[i]
-        for name in data_bins_labels:
+        for i in range(n_bins):
+            name = data_bins_labels[i]
+
             try:
                 data_tree_prefix = f"nHit{name}/data/count"
                 bkg_tree_prefix = f"nHit{name}/bkg/count"

--- a/hawc_hal/maptree/map_tree.py
+++ b/hawc_hal/maptree/map_tree.py
@@ -19,7 +19,7 @@ log = setup_logger(__name__)
 log.propagate = False
 
 
-def map_tree_factory(map_tree_file, roi, n_workers: int, n_transits=None):
+def map_tree_factory(map_tree_file, roi, n_workers: int = 1, n_transits=None):
     # Sanitize files in input (expand variables and so on)
     map_tree_file = sanitize_filename(map_tree_file)
 

--- a/hawc_hal/maptree/map_tree.py
+++ b/hawc_hal/maptree/map_tree.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division
 
 import os
-from builtins import object
 
 import astropy.units as u
 import numpy as np
@@ -29,7 +28,7 @@ def map_tree_factory(map_tree_file, roi, n_workers: int = 1, n_transits=None):
     return MapTree.from_hdf5(map_tree_file, roi, n_transits)
 
 
-class MapTree(object):
+class MapTree:
     def __init__(self, analysis_bins, roi, n_transits=None):
         self._analysis_bins = analysis_bins
         self._roi = roi
@@ -183,9 +182,9 @@ class MapTree(object):
         for bin_id in self._analysis_bins:
             analysis_bin = self._analysis_bins[bin_id]
 
-            assert (
-                bin_id == analysis_bin.name
-            ), "Bin name inconsistency: {} != {}".format(bin_id, analysis_bin.name)
+            assert bin_id == analysis_bin.name, "Bin name inconsistency: {} != {}".format(
+                bin_id, analysis_bin.name
+            )
 
             multi_index_keys.append(analysis_bin.name)
 

--- a/hawc_hal/obsolete/ts_map.py
+++ b/hawc_hal/obsolete/ts_map.py
@@ -1,228 +1,236 @@
 from __future__ import division
-from builtins import range
-from builtins import object
+
+from builtins import object, range
+
+import numpy as np
 from past.utils import old_div
 from threeML import *
-import numpy as np
-
 from threeML.io.logging import setup_logger
+
 log = setup_logger(__name__)
 log.propagate = False
 
-from hawc_hal.HAL import HAL
-from hawc_hal.region_of_interest import HealpixConeROI
-
-from astropy.wcs import WCS
+import matplotlib.pyplot as plt
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.io import fits as pyfits
-
-import matplotlib.pyplot as plt
-
-from threeML.parallel.parallel_client import ParallelClient, is_parallel_computation_active
+from threeML.parallel.parallel_client import (ParallelClient,
+                                              is_parallel_computation_active)
 from tqdm.auto import tqdm
-from threeML.io.fits_file import FITSFile
+
+from hawc_hal.HAL import HAL
+from hawc_hal.region_of_interest import HealpixConeROI
 
 crab_diff_flux_at_1_TeV = old_div(2.65e-11, (u.TeV * u.cm**2 * u.s))
 
 
 class ParallelTSmap(object):
-    
-    def __init__(self, maptree, response, ra_c, dec_c,  xsize, ysize, pix_scale, projection = 'AIT', roi_radius=3.0):
-
+    def __init__(
+        self,
+        maptree,
+        response,
+        ra_c,
+        dec_c,
+        xsize,
+        ysize,
+        pix_scale,
+        projection="AIT",
+        roi_radius=3.0,
+    ):
         # Create a new WCS object so that we can compute the appropriare R.A. and Dec
         # where we need to compute the TS
         self._wcs = wcs.WCS(naxis=2)
-        
+
         # The +1 is because the CRPIX should be in FORTRAN indexing, which starts at +1
         self._wcs.wcs.crpix = [xsize / 2.0, ysize / 2.0]
         self._wcs.wcs.cdelt = [-pix_scale, pix_scale]
         self._wcs.wcs.crval = [ra_c, dec_c]
         self._wcs.wcs.ctype = ["RA---%s" % projection, "DEC--%s" % projection]
-        
+
         self._ra_c = ra_c
         self._dec_c = dec_c
-        
+
         self._mtfile = maptree
         self._rsfile = response
-        
+
         self._points = []
-        
+
         # It is important that dec is the first one because the PSF for a Dec bin_name
         # is cached within one engine
-        
+
         max_d = 0
-        
+
         for idec in range(ysize):
-            
             for ira in range(xsize):
-                 
-                 this_ra, this_dec = self._wcs.wcs_pix2world(ira, idec, 0)
-                 
-                 self._points.append((this_ra, this_dec))
-                 
-                 d = angular_separation(*np.deg2rad((this_ra, this_dec, ra_c, dec_c)))
-                 
-                 if d > max_d:
-                     
-                     max_d = d
-                 
+                this_ra, this_dec = self._wcs.wcs_pix2world(ira, idec, 0)
+
+                self._points.append((this_ra, this_dec))
+
+                d = angular_separation(*np.deg2rad((this_ra, this_dec, ra_c, dec_c)))
+
+                if d > max_d:
+                    max_d = d
+
         log.info("Maximum distance from center: %.3f deg" % np.rad2deg(max_d))
-        
+
         # We keep track of how many ras we have so that when running in parallel all
         # the ras will run on the same engine with the same dec, maximizing the use
         # of the cache and minimizing the memory footprint
-        
+
         self._n_ras = xsize
         self._n_decs = ysize
-        
+
         self._roi_radius = float(roi_radius)
 
         roi = HealpixConeROI(self._roi_radius, ra=ra_c, dec=dec_c)
-        
+
         self._llh = HAL("HAWC", self._mtfile, self._rsfile, roi)
-        self._llh.set_active_measurements(1,9)
-        
+        self._llh.set_active_measurements(1, 9)
+
         # Make a fit with no source to get the likelihood for the null hypothesis
         model = self.get_model(0)
-        model.TestSource.spectrum.main.shape.K = model.TestSource.spectrum.main.shape.K.min_value
-        
+        model.TestSource.spectrum.main.shape.K = (
+            model.TestSource.spectrum.main.shape.K.min_value
+        )
+
         self._llh.set_model(model)
-        
+
         self._like0 = self._llh.get_log_like()
-        
+
         # We will fill this with the maximum of the TS map
-        
+
         self._max_ts = None
-    
+
     def get_data(self, interval_id):
-        
         datalist = DataList(self._llh)
-        
+
         return datalist
-     
+
     def get_model(self, interval_id):
-        
         spectrum = Powerlaw()
-        
+
         this_ra = self._points[interval_id][0]
         this_dec = self._points[interval_id][1]
-        
-        this_source = PointSource("TestSource", ra=this_ra, dec=this_dec, spectral_shape=spectrum)
-        
+
+        this_source = PointSource(
+            "TestSource", ra=this_ra, dec=this_dec, spectral_shape=spectrum
+        )
+
         spectrum.piv = 1 * u.TeV
         spectrum.piv.fix = True
-                
+
         # Start from a flux 1/10 of the Crab
         spectrum.K = crab_diff_flux_at_1_TeV
         spectrum.K.bounds = (1e-30, 1e-18)
         spectrum.index = -2.63
         spectrum.index.fix = False
-        
+
         model1 = Model(this_source)
-    
+
         return model1
-    
+
     def worker(self, interval_id):
-        
         model = self.get_model(interval_id)
         data = self.get_data(interval_id)
-        
+
         jl = JointLikelihood(model, data)
         jl.set_minimizer("ROOT")
         par, like = jl.fit(quiet=True)
-        
-        return like['-log(likelihood)']['HAWC']
 
-    
+        return like["-log(likelihood)"]["HAWC"]
+
     def go(self):
-                
         if is_parallel_computation_active():
-        
             client = ParallelClient()
-            
-            if self._n_decs % client.get_number_of_engines() != 0:
-                
-                log.warning("The number of Dec bands is not a multiple of the number of engine. Make it so for optimal performances.", RuntimeWarning)
-            
-            res = client.execute_with_progress_bar(self.worker, list(range(len(self._points))), chunk_size=self._n_ras)
-        
-        else:
-            
-            n_points = len(self._points)
-            
-            p = tqdm(total=n_points)
-            
-            res = np.zeros(n_points)
-                
-            for i, point in enumerate(self._points):
 
+            if self._n_decs % client.get_number_of_engines() != 0:
+                log.warning(
+                    "The number of Dec bands is not a multiple of the number of engine. Make it so for optimal performances.",
+                    RuntimeWarning,
+                )
+
+            res = client.execute_with_progress_bar(
+                self.worker, list(range(len(self._points))), chunk_size=self._n_ras
+            )
+
+        else:
+            n_points = len(self._points)
+
+            p = tqdm(total=n_points)
+
+            res = np.zeros(n_points)
+
+            for i, point in enumerate(self._points):
                 res[i] = self.worker(i)
 
                 p.update(1)
-        
+
         TS = 2 * (-np.array(res) - self._like0)
-        
-        #self._debug_map = {k:v for v,k in zip(self._points, TS)}
-        
+
+        # self._debug_map = {k:v for v,k in zip(self._points, TS)}
+
         # Get maximum of TS
         idx = TS.argmax()
         self._max_ts = (TS[idx], self._points[idx])
-        
-        log.info("Maximum TS is %.2f at (R.A., Dec) = (%.3f, %.3f)" % (self._max_ts[0], self._max_ts[1][0], self._max_ts[1][1]))
-         
+
+        log.info(
+            "Maximum TS is %.2f at (R.A., Dec) = (%.3f, %.3f)"
+            % (self._max_ts[0], self._max_ts[1][0], self._max_ts[1][1])
+        )
+
         self._ts_map = TS.reshape(self._n_decs, self._n_ras)
-        
+
         return self._ts_map
-    
+
     @property
     def maximum_of_map(self):
-        
         return self._max_ts
-    
-    def to_fits(self, filename, overwrite=True):
-        
-        primary_hdu = pyfits.PrimaryHDU(data=self._ts_map, header=self._wcs.to_header())
-        
-        primary_hdu.writeto(filename, overwrite=overwrite)
-    
-    def plot(self):
-        
-        # Draw TS map
-        
-        fig, ax = plt.subplots(subplot_kw = {'projection': self._wcs})
 
-        plt.imshow(self._ts_map, origin='lower', interpolation='none')
-        
+    def to_fits(self, filename, overwrite=True):
+        primary_hdu = pyfits.PrimaryHDU(data=self._ts_map, header=self._wcs.to_header())
+
+        primary_hdu.writeto(filename, overwrite=overwrite)
+
+    def plot(self):
+        # Draw TS map
+
+        fig, ax = plt.subplots(subplot_kw={"projection": self._wcs})
+
+        plt.imshow(self._ts_map, origin="lower", interpolation="none")
+
         # Draw colorbar
-        
+
         cbar = plt.colorbar(format="%.1f")
-        
+
         cbar.set_label("TS")
-        
+
         # Plot 1, 2 and 3 sigma contour
-        _ = plt.contour(self._ts_map, origin='lower', 
-                        levels=self._ts_map.max() - np.array([4.605, 7.378, 9.210][::-1]),
-                        colors=['black', 'blue','red'])
-        
+        _ = plt.contour(
+            self._ts_map,
+            origin="lower",
+            levels=self._ts_map.max() - np.array([4.605, 7.378, 9.210][::-1]),
+            colors=["black", "blue", "red"],
+        )
+
         # Access the first WCS coordinate
         ra = ax.coords[0]
         dec = ax.coords[1]
-        
+
         # Set the format of the tick labels
-        ra.set_major_formatter('d.ddd')
-        dec.set_major_formatter('d.ddd')
-        
-        plt.xlabel('R.A. (J2000)')
-        plt.ylabel('Dec. (J2000)')
-        
+        ra.set_major_formatter("d.ddd")
+        dec.set_major_formatter("d.ddd")
+
+        plt.xlabel("R.A. (J2000)")
+        plt.ylabel("Dec. (J2000)")
+
         # Overlay the center
-        
-        ax.scatter([self._ra_c],[self._dec_c], transform=ax.get_transform('world'), marker='o')
-        
+
+        ax.scatter(
+            [self._ra_c], [self._dec_c], transform=ax.get_transform("world"), marker="o"
+        )
+
         # Overlay the maximum TS
         ra_max, dec_max = self._max_ts[1]
-        
-        ax.scatter([ra_max],[dec_max], transform=ax.get_transform('world'), marker='x')
-        
-        return fig
 
+        ax.scatter([ra_max], [dec_max], transform=ax.get_transform("world"), marker="x")
+
+        return fig

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -8,9 +8,12 @@ import pandas as pd
 import scipy.integrate
 import scipy.interpolate
 import scipy.optimize
+from numpy.typing import NDArray
 from past.utils import old_div
 
 _INTEGRAL_OUTER_RADIUS = 15.0
+
+ndarray = NDArray[np.float64]
 
 
 class InvalidPSFError(ValueError):
@@ -165,18 +168,28 @@ class PSFWrapper(object):
 
     @staticmethod
     def psf_func(ang_dist: float, psf_best_fit_params: np.ndarray) -> float:
-        """
-        ### Analytical function of PSF
-        * The analytical form of PSF needs to be declared here given
-        that uproot is simply an I/O framework meant to read the
-        information from TTree objects, with no ROOT functionality
+        """Analytical function of PSF
 
-        Args:
-            ang_dist (float): angular distances
-            psf_best_fit_params (np.ndarray): best-fit parameters read from response file
+        Parameters
+        ----------
+        ang_dist : float
+            Angular distances
 
-        Returns:
-            float: Returns expected counts provided with angular distances as input
+        psf_best_fit_params : np.ndarray
+            best-fit parameters read from the ROOT response file
+
+
+        Returns
+        -------
+        float
+            Expected counts provided with angular distances as input
+        Notes
+        -----
+
+            The function is declared here given that uproot is simply an I/O
+            framework meant to read the information from TTree objects with no
+            ROOT functionality.
+
         """
         return psf_best_fit_params[0] * (
             ang_dist
@@ -193,15 +206,21 @@ class PSFWrapper(object):
         )
 
     @classmethod
-    def psf_eval(cls, fun_parameters):
-        """Evaluate the PSF function
+    def psf_eval(cls, fun_parameters: ndarray):
+        """Eavluate the PSF function and retrieve expected counts
 
-        Args:
-            fun_parameters (list): Best-fit parameters read from response file
+        Parameters
+        ----------
+        fun_parameters : NDArray[np.float64]
+            Best-fit parameters read from response file
 
-        Returns:
-            PSFWrapper: returns an instance os PSF with tuple
-            of (angular distances, expected counts)
+
+        Returns
+        -------
+        PSFWrapper
+                Returns an instance of PSF with tuple
+                of (angular distances, expected counts)
+
         """
 
         # uproot has no methods to act on histograms. Therefore, using scipy

--- a/hawc_hal/psf_fast/psf_wrapper.py
+++ b/hawc_hal/psf_fast/psf_wrapper.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import copy
 from builtins import object, zip
-from typing import Self
 
 import numpy as np
 import pandas as pd
@@ -11,6 +10,9 @@ import scipy.interpolate
 import scipy.optimize
 from numpy.typing import NDArray
 from past.utils import old_div
+from typing_extensions import Self
+
+# from typing import Self # available on python 3.11+
 
 _INTEGRAL_OUTER_RADIUS = 15.0
 

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -336,26 +336,18 @@ class HAWCResponse(object):
 
     @classmethod
     def from_root_file(cls, response_file_name: Path, n_workers: int = 1):
-        """Read the response ROOT file. Do not use directly, use the
-        hawc_response_factory method instead.
+        """Read the response ROOT file. Do not use directly, use the hawc_response_factory()
+        method instead.
 
-        Parameters
-        ----------
-        response_file_name : Path
-            Response ROOT file path
-        n_workers : int
-            Number of workers to use for multiprocessing
+        :param response_file_name: file path to response ROOT file
+        :type response_file_name: Path
+        :param n_workers: number of processes to parallelize reading of ROOT file with uproot
+        :type n_workers: int
+        :raises IOError: File is either nonexistent or corrupt
+        :return: HAWCResponse object containing the response bins for all declinations within
+        the ROOT file
+        :rtype: HAWCREsponse
 
-        Returns
-        -------
-        HAWCResponse :
-            HAWC response file object containing the response bins for declinations
-            within the ROOT file
-
-        Raises
-        ------
-        IOError
-            This exception will be raised if the file provided does not exists or is not readable
         """
 
         # Make sure file is readable
@@ -429,17 +421,15 @@ class HAWCResponse(object):
 
         return cls(response_file_name, dec_bins, response_bins)
 
-    def get_response_dec_bin(self, dec, interpolate=False):
-        """Get the response for the provided declination bin, optionally interpolating the PSF
+    def get_response_dec_bin(self, dec: float, interpolate=False):
+        """Get the response bin for a given declination.
 
-
-        Args:
-            dec (float): Declination where the response is desired
-            interpolate (bool, optional): If True, PSF is interpolated between the two
-            closest response bins. Defaults to False.
-
-        Returns:
-            PSFWrapper: To be added later.
+        :param dec: user provided source or ROI declination
+        :type dec: float
+        :param interpolate: Interpolate over response bins, defaults to False
+        :type interpolate: bool
+        :return: Dictionary of response bins that coincide with the user provided declination
+        :rtype: OrderedDict[str, HAWCResponseBin]
         """
 
         # Sort declination bins by distance to the provided declination

--- a/hawc_hal/response/response.py
+++ b/hawc_hal/response/response.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division
 
 import collections
+import concurrent.futures
 import os
 from builtins import object, zip
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -324,7 +324,9 @@ class HAWCResponse(object):
             dec_bins = list(zip(dec_bins_lower_edge, dec_bins_sim, dec_bins_upper_edge))
             number_of_dec_bins = len(dec_bins_sim)
 
-            with ProcessPoolExecutor(max_workers=n_workers) as executor:
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=n_workers
+            ) as executor:
                 results = executor.map(
                     resp_metadata.generate_metadata, list(range(number_of_dec_bins))
                 )

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -1,10 +1,115 @@
-from builtins import range
+""" Generate ResponseBin for HAWC Likelihood plugin"""
 from builtins import object
-import uproot
+from dataclasses import dataclass, field
+
+import boost_histogram as bh
 import numpy as np
 import pandas as pd
 
-from ..psf_fast import PSFWrapper, InvalidPSF, InvalidPSFError
+from ..psf_fast import InvalidPSF, InvalidPSFError, PSFWrapper
+
+# NOTE: definition of a few constants to be used thorought the module
+LOG_BASE: int = 10
+
+
+@dataclass
+class EnergyBin:
+    """
+    # EnergyBin
+    ### Intermediate class to retrieve values from energy histograms of ROOT file
+
+    #### Args:
+        * signal_events (np.ndarray): simulated signal events
+        * bkg_events (np.ndarray): simulated background events
+        * log_log_params (np.ndarray): best-fit parameters obtained from response file
+        * log_log_shape (str): spectral shape
+
+    """
+
+    bin_name: str
+    signal_events: bh.Histogram
+    bkg_events: bh.Histogram
+    log_log_params: np.ndarray
+    log_log_shape: str
+
+    # Variables to be initialized with the _get_edges method
+    _lower_edges: np.ndarray = field(init=False)
+    _centers: np.ndarray = field(init=False)
+    _upper_edges: np.ndarray = field(init=False)
+
+    def _log_log_spectrum(self, log_energy: float, log_log_shape: str) -> float:
+        """Evaluate the differential flux from log10(simulate energy) values
+
+        Args:
+            log_energy (float): simulated energy in log10 scale
+            parameters (np.ndarray): best-fit parameters obtained from response file
+
+        Returns:
+            float: returns differential flux in units (TeV^-1 cm^-2 s^-1) in log10 scale
+        """
+        parameters = self.log_log_params
+
+        if log_log_shape == "SimplePowerLaw":
+            return np.log10(parameters[0]) - parameters[1] * log_energy
+
+        if log_log_shape == "CutOffPowerLaw":
+            return (
+                np.log10(parameters[0])
+                - parameters[1] * log_energy
+                - np.log10(np.exp(1.0))
+                * np.power(10.0, log_energy - np.log10(parameters[2]))
+            )
+
+        raise ValueError("Unknown spectral shape.")
+
+    def _get_edges(self) -> None:
+        """Read the lower, center and upper edges of the energy bins"""
+        self._lower_edges = np.array(self.signal_events.axes.edges[0][:-1])
+        self._centers = np.array(self.signal_events.axes.centers[0])
+        self._upper_edges = np.array(self.signal_events.axes.edges[0][1:])
+
+    @property
+    def get_differential_fluxes(self) -> np.ndarray:
+        """Calculate the differential fluxes with log energy values"""
+        self._get_edges()
+        differential_fluxes = np.array(
+            [
+                self._log_log_spectrum(log_energy, self.log_log_shape)
+                for log_energy in self._centers
+            ]
+        )
+
+        return LOG_BASE**differential_fluxes
+
+    @property
+    def get_energy_bin_low(self) -> np.ndarray:
+        """Energy bins lower edge"""
+        return LOG_BASE**self._lower_edges
+
+    @property
+    def get_energy_bin_upper(self) -> np.ndarray:
+        """Energy bins upper edge"""
+        return LOG_BASE**self._upper_edges
+
+    @property
+    def get_energy_bin_centers(self) -> np.ndarray:
+        """Energy bins center edge"""
+        return LOG_BASE**self._centers
+
+    @property
+    def get_signal_events(self) -> np.ndarray:
+        """Retrieve simulated signal events"""
+        return self.signal_events.values()
+
+    @property
+    def get_bkg_events(self) -> np.ndarray:
+        """Retrieve simulated background events"""
+        return self.bkg_events.values()
+
+    @property
+    def get_bin_name(self) -> str:
+        """Retrieve name of analysis name"""
+        return self.bin_name
 
 
 class ResponseBin(object):
@@ -28,7 +133,6 @@ class ResponseBin(object):
         sim_signal_events_per_bin,
         psf,
     ):
-
         self._name = name
         self._min_dec = min_dec
         self._max_dec = max_dec
@@ -42,37 +146,35 @@ class ResponseBin(object):
         self._sim_signal_events_per_bin = sim_signal_events_per_bin
         self._psf = psf  # type: PSFWrapper
 
-    @staticmethod
-    def _get_en_th1d(
-        open_ttree: uproot.ReadOnlyDirectory,
-        dec_id: int,
-        analysis_bin_id: str,
-        prefix: str,
-    ):
+    # ? In the middle of refactoring some of the code, so this might or might
+    # ? not be useful
+    # @staticmethod
+    # def _get_en_th1d(
+    #     open_ttree: uproot.ReadOnlyDirectory,
+    #     dec_id: int,
+    #     analysis_bin_id: str,
+    #     prefix: str,
+    # ):
+    #     en_sig_label = f"En{prefix}_dec{dec_id}_nh{analysis_bin_id}"
 
-        en_sig_label = f"En{prefix}_dec{dec_id}_nh{analysis_bin_id}"
+    #     hist_prefix = f"dec_{dec_id:02d}/nh_{analysis_bin_id}/{en_sig_label}"
+    #     if open_ttree.get(hist_prefix, None) is None:
+    #         hist_prefix = f"dec_{dec_id:02d}/nh_0{analysis_bin_id}/{en_sig_label}"
 
-        try:
-            hist_prefix = f"dec_{dec_id:02d}/nh_{analysis_bin_id}/{en_sig_label}"
-            this_en_th1d = open_ttree[hist_prefix].to_hist()
+    #     this_en_th1d = open_ttree[hist_prefix].to_hist()
 
-        except uproot.KeyInFileError:
+    #     if not this_en_th1d:
+    #         raise IOError(f"Could not find TH1D named {en_sig_label}.")
 
-            hist_prefix = f"dec_{dec_id:02d}/nh_0{analysis_bin_id}/{en_sig_label}"
-            this_en_th1d = open_ttree[hist_prefix].to_hist()
-
-        if not this_en_th1d:
-
-            raise IOError(f"Could not find TH1D named {en_sig_label}.")
-
-        return this_en_th1d
+    #     return this_en_th1d
 
     @classmethod
     def from_ttree(
         cls,
-        root_file: uproot.ReadOnlyDirectory,
-        dec_id: int,
         analysis_bin_id: str,
+        energy_hist: bh.Histogram,
+        energy_hist_bkg: bh.Histogram,
+        psf_fit_params: list[float],
         log_log_params: np.ndarray,
         log_log_shape: str,
         min_dec: np.ndarray,
@@ -82,96 +184,46 @@ class ResponseBin(object):
         """
         Obtain the information from Response ROOT file
 
-        Args:
-            root_file (object): ROOT object reading information with uproot functionality
-            dec_id (int): declination band id
-            analysis_bin_id (str): data analysis name
-            log_log_params (np.ndarray): params from LogLogSpectrum TF1
-            min_dec (np.ndarray): numpy array with lower declination bin edges
-            dec_center (np.ndarray): numpy array with declination center values
-            max_dec (np.ndarray): numpy array with upper declination bin edges
+        #### Args:
+            * root_file (object): ROOT object reading information with uproot functionality
+            * dec_id (int): declination band id
+            * analysis_bin_id (str): data analysis name
+            * log_log_params (np.ndarray): params from LogLogSpectrum TF1
+            * min_dec (np.ndarray): numpy array with lower declination bin edges
+            * dec_center (np.ndarray): numpy array with declination center values
+            * max_dec (np.ndarray): numpy array with upper declination bin edges
         """
 
-        def log_log_spectrum(log_energy: float, parameters: np.ndarray):
-            """Evaluate the differential flux from log10(simulate energy) values
-
-            Args:
-                log_energy (float): simulated energy in log10 scale
-                parameters (np.ndarray): best-fit parameters obtained from response file
-
-            Returns:
-                float: returns differential flux in units (TeV^-1 cm^-2 s^-1) in log10 scale
-            """
-
-            if log_log_shape == "SimplePowerLaw":
-
-                return np.log10(parameters[0]) - parameters[1] * log_energy
-
-            if log_log_shape == "CutOffPowerLaw":
-
-                return (
-                    np.log10(parameters[0])
-                    - parameters[1] * log_energy
-                    - np.log10(np.exp(1.0)) * np.power(10.0, log_energy - np.log10(parameters[2]))
-                )
-
-            else:
-                raise ValueError("Unknown spectral shape.")
-
-        this_en_sig_th1d = cls._get_en_th1d(root_file, dec_id, analysis_bin_id, prefix="Sig")
-
-        this_en_bg_th1d = cls._get_en_th1d(root_file, dec_id, analysis_bin_id, prefix="Bg")
-
-        total_bins = this_en_sig_th1d.shape[0]
-        sim_energy_bin_low = np.zeros(total_bins)
-        sim_energy_bin_centers = np.zeros(total_bins)
-        sim_energy_bin_high = np.zeros(total_bins)
-        sim_signal_events_per_bin = np.zeros_like(sim_energy_bin_centers)
-        sim_differential_photon_fluxes = np.zeros_like(sim_energy_bin_centers)
-
-        # The sum of the histogram is the total number of simulated events detected
-        # in this analysis bin_name
-        sim_n_sig_events = this_en_sig_th1d.values().sum()
+        # NOTE: Load all the information to the EnergyBin class for each bin_name
+        # and for the complex processing of the differential flux,
+        # energy lower_edges, centers, upper_edges
+        energy_bin = EnergyBin(
+            analysis_bin_id,
+            energy_hist,
+            energy_hist_bkg,
+            log_log_params,
+            log_log_shape,
+        )
 
         # Now let's see what has been simulated, i.e., the differential flux
         # at the center of each bin_name of the en_sig histogram
-        bin_lower_edges = this_en_sig_th1d.axes.edges[0][:-1]
-        bin_upper_edges = bin_lower_edges + this_en_sig_th1d.axes.widths[0]
-        bin_centers = this_en_sig_th1d.axes.centers[0]
-        bin_signal_events = this_en_sig_th1d.values()
+        sim_differential_photon_fluxes = energy_bin.get_differential_fluxes
+        sim_energy_bin_low = energy_bin.get_energy_bin_low
+        sim_energy_bin_centers = energy_bin.get_energy_bin_centers
+        sim_energy_bin_high = energy_bin.get_energy_bin_upper
 
-        for i in range(this_en_sig_th1d.shape[0]):
-
-            sim_energy_bin_low[i] = 10 ** bin_lower_edges[i]
-            sim_energy_bin_centers[i] = 10 ** bin_centers[i]
-            sim_energy_bin_high[i] = 10 ** bin_upper_edges[i]
-
-            # NOTE: doesn't have the ability to read and evaluate TF1
-            sim_differential_photon_fluxes[i] = 10 ** (
-                log_log_spectrum(bin_centers[i], log_log_params)
-            )
-
-            sim_signal_events_per_bin[i] = bin_signal_events[i]
-
-        # Read the histogram of the bkg events detected in this bin_name
-        # Note: we do not copy this TH1D instance because we don't need it after the file is close
-        sim_n_bg_events = this_en_bg_th1d.values().sum()
+        sim_signal_events_per_bin = energy_bin.get_signal_events
 
         # Now read the various TF1(s) for PSF, signal and background
-        # Read the PSF and make a copy (so it will stay when we close the file)
+        # The sum of the histogram is the total number of simulated events detected
+        # in this analysis bin_name
+        sim_n_sig_events = energy_bin.get_signal_events.sum()
+        sim_n_bg_events = energy_bin.get_bkg_events.sum()
+
         # NOTE: uproot doesn't have the ability to read and evaluate TF1
-        try:
-
-            psf_prefix = f"dec_{dec_id:02d}/nh_{analysis_bin_id}"
-            psf_tf1_metadata = root_file[f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"]
-        except uproot.KeyInFileError:
-
-            psf_prefix = f"dec_{dec_id:02d}/nh_0{analysis_bin_id}"
-            psf_tf1_metadata = root_file[f"{psf_prefix}/PSF_dec{dec_id}_nh{analysis_bin_id}_fit"]
-
-        psf_tf1_fparams = psf_tf1_metadata.member("fParams")
-
-        psf_fun = PSFWrapper.psf_eval(psf_tf1_fparams)
+        # but we pass the psf_params to the PSFWrapper class which can
+        # evaluate the PSF function for us
+        psf_fun = PSFWrapper.psf_eval(psf_fit_params)
 
         return cls(
             analysis_bin_id,
@@ -241,7 +293,9 @@ class ResponseBin(object):
         n_sim_signal_events = (
             w1 * self._sim_n_sig_events + w2 * other_response_bin._sim_n_sig_events
         )
-        n_sim_bkg_events = w1 * self._sim_n_bg_events + w2 * other_response_bin._sim_n_bg_events
+        n_sim_bkg_events = (
+            w1 * self._sim_n_bg_events + w2 * other_response_bin._sim_n_bg_events
+        )
 
         # We assume that the bin centers are the same
         assert np.allclose(

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -38,14 +38,14 @@ class EnergyBin:
     _upper_edges: np.ndarray = field(init=False)
 
     def _log_log_spectrum(self, log_energy: float, log_log_shape: str) -> float:
-        """Evaluate the differential flux from log10(simulate energy) values
+        """Evluate the differential flux from log10(simulated energy) values
 
-        Args:
-            log_energy (float): simulated energy in log10 scale
-            parameters (np.ndarray): best-fit parameters obtained from response file
-
-        Returns:
-            float: returns differential flux in units (TeV^-1 cm^-2 s^-1) in log10 scale
+        :param log_energy: simulated energy in log10 scale units (TeV)
+        :type log_energy: float
+        :param log_log_shape: best-fit paraemters obtained from response file
+        :type log_log_shape: str
+        :raises ValueError: There is an unknown spectral shape provided
+        :return: Differential flux in units (TeV^-1 cm^-2 s^-1) in log10 scale
         """
         parameters = self.log_log_params
 
@@ -181,17 +181,29 @@ class ResponseBin(object):
         dec_center: np.ndarray,
         max_dec: np.ndarray,
     ):
-        """
-        Obtain the information from Response ROOT file
+        """Read in the response file with ROOT format and organize all the necessary
+        information
 
-        #### Args:
-            * root_file (object): ROOT object reading information with uproot functionality
-            * dec_id (int): declination band id
-            * analysis_bin_id (str): data analysis name
-            * log_log_params (np.ndarray): params from LogLogSpectrum TF1
-            * min_dec (np.ndarray): numpy array with lower declination bin edges
-            * dec_center (np.ndarray): numpy array with declination center values
-            * max_dec (np.ndarray): numpy array with upper declination bin edges
+        :param analysis_bin_id: Active analysis bin name defined in the response file
+        :type analysis_bin_id: str
+        :param energy_hist: Energy histogram from response file
+        :type energy_hist: boost_histogram
+        :param energy_hist_bkg: Background energy histogram from response file
+        :type energy_hist_bkg: boost_histogram
+        :param psf_fit_params: Best-fit PSF parameters for the active analysis_bin
+        :type psf_fit_params: list[float]
+        :param log_log_params: Best-fit params of the LogLogSpectrum TF1
+        :type log_log_params: np.ndarray
+        :param log_log_shape: Name of the spectral shape used to fit the PSF TF1
+        :type log_log_shape: str
+        :param min_dec: Lower declination edges
+        :type min_dec: np.ndarray
+        :param dec_center: Declination bin centers
+        :type dec_center: np.ndarray
+        :param max_dec: Upper declination edges
+        :type max_dec: np.ndarray
+        :return: ResponseBin object with all the necessary information for a given analysis_bin
+        :rtype: ResponseBin
         """
 
         # NOTE: Load all the information to the EnergyBin class for each bin_name

--- a/hawc_hal/response/response_bin.py
+++ b/hawc_hal/response/response_bin.py
@@ -1,14 +1,15 @@
 """ Generate ResponseBin for HAWC Likelihood plugin"""
 from dataclasses import dataclass, field
-from typing import Self
 
 import boost_histogram as bh
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
+from typing_extensions import Self
 
 from ..psf_fast import InvalidPSF, InvalidPSFError, PSFWrapper
 
+# from typing import Self # available on python 3.11+
 # NOTE: definition of a few constants to be used thorought the module
 LOG_BASE: int = 10
 ndarray = NDArray[np.float64]

--- a/hawc_hal/tests/test_n_transits.py
+++ b/hawc_hal/tests/test_n_transits.py
@@ -19,7 +19,7 @@ def test_transits(maptree, roi):
     # Case 1: specify number of transits
 
     n_transits = 777.7
-    maptree_ntransits = map_tree_factory(maptree,roi_,n_transits)
+    maptree_ntransits = map_tree_factory(maptree,roi_,n_transits=n_transits, n_workers=1)
 
     # does the maptree return the specified transits?
     check_n_transits(maptree_ntransits, n_transits)


### PR DESCRIPTION
# Summary of changes:

The reading of ROOT files is now faster by parallelizing the reading of ROOT files with multiprocessing.Pool.

## Multiprocessing the reading of ROOT files
This pull request improves the loading time for reading ROOT files with the multiprocessing module. I use the `multiprocessing.Pool` which generates a process pool that spawns a number of processes which can bypass python's Global Interpreter Lock (GIL). The changes have been implemented info  `from_root_file.py` use this feature and `response.py`.  Loading of the ROOT files greatly improves especially for energy estimators which used to take around 5-7 minutes.


## How to enable this:
The changes are enabled by providing a n_workers parameter to HAL. For example,

` 
hawc_like = HAL("HAWC", maptree, response, roi, n_workers=2)
`
The number of workers should not exceed the number of available cores. 

## Further changes:
Major refactoring of the code for both map tree and response file modules. Some of the changes are compatible with python 3.10+ so it will require updating to a newer environment. threeML is yet not ready for python 3.11, but the current changes work as of python 3.10.13. 

Feel free to test the changes and let me know if there are any issues.