### PR TITLE
uproot 5.2+ slows down the reading of HAWC's ROOT files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "numba",
         "reproject",
         "tqdm",
-        "uproot",
+        "uproot==5.1.2",
         "awkward",
         "mplhep",
         "hist",


### PR DESCRIPTION
Uproot 5.2 introduced changes that increases the reading of HAWC's ROOT files. Until I figure out how to deal with this and obtain the same performance I'd like to pin the version to the release where I see the most performance gain, which is `5.1.2`.