### PR TITLE
Fixing uproot

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ response = ... # This can be either a ROOT or hdf5 file
 hawc = HAL("HAWC",
            maptree,
            response,
-           roi)
+           roi,
+           n_workers=3) # enables ability of loading ROOT's files faster with multiprocessing
 
 # Use from bin 1 to bin 9
 hawc.set_active_measurements(1, 9)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "threeml",
         "astromodels",
         "pandas",
-        "healpy",
+        "pytest",
         "six",
         "astropy",
         "scipy",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "numba",
         "reproject",
         "tqdm",
-        "uproot==5.1.2",
+        "uproot",
         "awkward",
         "mplhep",
         "hist",


### PR DESCRIPTION
# Summary
Previously, I had added the ability of reading ROOT files with multiprocessing to reduce the loading time. `uproot 5.2+` seems to have to be introduced changes that broke that functionality. However, I have fixed these issues in this branch and would like to incorporate the changes to the master branch.

## Changes
- [x] I've added a handler option for the reading of ROOT files so that HAL can load maptrees and response files faster.
- [x] This also lifts the version freeze from the PR #94 . 