### PR TITLE
Adding a pyproject toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,21 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "hawc_hal"
-version = "1.0"
+version = "1.1"
 authors = ["Giacomo Vianello <giacomov@stanford.edu>"]
 maintainers = [
-  "Ramiro Torres-Escobedo <rtorrese@proton.me>",
   "Xiaojie Wang <xwang32@mtu.edu>",
+  "Ramiro Torres-Escobedo <rtorrese@proton.me>",
 ]
 description = "HAWC Accelerated Likelihood; Read and handle HAWC data"
-license = "BSD-3.0"
+license = "BSD-3-Clause"
 packages = [{ include = "hawc_hal" }, { include = "scripts" }]
+
+[tool.poetry.urls]
+homepage = "https://threeml.readthedocs.io/en/stable/index.html"
+repository = "https://github.com/threeML/hawc_hal"
+documentation = "https://threeml.readthedocs.io/en/stable/notebooks/hal_example.html"
+"Bug Tracker" = "https://github.com/threeML/hawc_hal/issues"
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -33,20 +39,16 @@ uproot = "*"
 awkward = "*"
 mplhep = "*"
 hist = "*"
+ruff = "*"
+pyright = "*"
 
 
 [tool.poetry.scripts]
 hdf5tofits = "scripts.hal_hdf5_to_fits:main"
 halfitpointsrc = "scripts.hal_fit_point_source:main"
 
-[tool.poetry.package.include]
-format = "sdist"
-path = "hawc_hal/tests/data"
-
 [tool.ruff]
-exclude = ["codecov.yml", "data/*", "ci/*", "notebooks"]
-# docstring-code-format = true
-# docstring-code-line-length = 60
+exclude = ["codecov.yml", "data/*", "ci/*", "notebooks", "tests"]
 line-length = 88
 indent-width = 4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,43 @@ hdf5tofits = "scripts.hal_hdf5_to_fits:main"
 halfitpointsrc = "scripts.hal_fit_point_source:main"
 
 [tool.ruff]
-exclude = ["codecov.yml", "data/*", "ci/*", "notebooks", "tests"]
+include = [
+  "pyproject.toml",
+  "hawc_hal/**/*.py",
+  "scripts/**/*.py",
+  "notebooks/**/*.ipynb",
+]
+exclude = [
+  "codecov.yml",
+  "data/*",
+  "ci/*",
+  "notebooks",
+  "tests",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".ipynb_checkpoints",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pyenv",
+  ".pytest_cache",
+  ".pytype",
+  ".ruff_cache",
+  ".venv",
+  ".vscode",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "site-packages",
+  "venv",
+]
 line-length = 88
 indent-width = 4
+docstring-code-format = false
 
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ path = "hawc_hal/tests/data"
 
 [tool.ruff]
 exclude = ["codecov.yml", "data/*", "ci/*", "notebooks"]
-docstring-code-format = true
-docstring-code-line-length = 60
+# docstring-code-format = true
+# docstring-code-line-length = 60
 line-length = 88
 indent-width = 4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "hawc_hal"
+version = "1.0"
+authors = ["Giacomo Vianello <giacomov@stanford.edu>"]
+maintainers = [
+  "Ramiro Torres-Escobedo <rtorrese@proton.me>",
+  "Xiaojie Wang <xwang32@mtu.edu>",
+]
+description = "HAWC Accelerated Likelihood; Read and handle HAWC data"
+license = "BSD-3.0"
+packages = [{ include = "hawc_hal" }, { include = "scripts" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+numpy = ">=1.14"
+healpy = "*"
+threeml = "*"
+astromodels = "*"
+pandas = "*"
+pytest = "*"
+six = "*"
+astropy = "*"
+scipy = "*"
+matplotlib = "*"
+numba = "*"
+reproject = "*"
+tqdm = "*"
+uproot = "*"
+awkward = "*"
+mplhep = "*"
+hist = "*"
+
+
+[tool.poetry.scripts]
+hdf5tofits = "scripts.hal_hdf5_to_fits:main"
+halfitpointsrc = "scripts.hal_fit_point_source:main"
+
+[tool.poetry.package.include]
+format = "sdist"
+path = "hawc_hal/tests/data"
+
+[tool.ruff]
+exclude = ["codecov.yml", "data/*", "ci/*", "notebooks"]
+docstring-code-format = true
+docstring-code-line-length = 60
+line-length = 88
+indent-width = 4
+
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+line-length = 90
+target-version = "py310"
+[lint]
+select = ["F"]
+ignore = ["E501"]
+
+# [lint.isort]
+# line-after-imports = 2
+
+[format]
+quote-style = "double"
+docstring-code-format = true
+docstring-code-line-length = 60
+skip-magic-trailing-comma = true
+# quote-style = "single"


### PR DESCRIPTION
Several users have reported an issue with installing `hawc_hal` with the command `pip install git+https://github.com/threeML/hawc_hal.git`


```python

Collecting git+https://github.com/threeml/hawc_hal.
Cloning https://github.com/threeml/hawc_hal.git to /tmp/pip-req-build-qbgct1ii                                                                                                                                
Running command git clone --quiet https://github.com/threeml/hawc_hal.git /tmp/pip-req-build-qbgct1ii                                                                                                         
Resolved https://github.com/threeml/hawc_hal.git to commit 6696aee33541ff8b994937c3c0125d710785f8b5                                                                                                           
Preparing metadata (setup.py) ... error                                                                                                                                                                       
error: subprocess-exited-with-error                                                                                                                                                                           

× python setup.py egg_info did not run successfully.                                                                                                                                                          
│ exit code: 1                                                                                                                                                                                                
╰─> [45 lines of output]                                                                                                                                                                                      
running egg_info                                                                                                                                                                                              
creating /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info                                                                                                                                                     
writing /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/PKG-INFO                                                                                                                                             
writing dependency_links to /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/dependency_links.txt                                                                                                             
writing entry points to /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/entry_points.txt                                                                                                                     
writing requirements to /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/requires.txt                                                                                                                         
writing top-level names to /tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/top_level.txt                                                                                                                     
writing manifest file '/tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/SOURCES.txt'                                                                                                                          
reading manifest file '/tmp/pip-pip-egg-info-pdpa_at2/hawc_hal.egg-info/SOURCES.txt'                                                                                                                          
adding license file 'LICENSE'                                                                                                                                                                                 
Traceback (most recent call last):                                                                                                                                                                            
File "<string>", line 2, in <module>                                                                                                                                                                          
File "<pip-setuptools-caller>", line 34, in <module>                                                                                                                                                          
File "/tmp/pip-req-build-qbgct1ii/setup.py", line 22, in <module>                                                                                                                                             
setup(                                                                                                                                                                                                        
File "/data/disk01/home/ibrahimo/miniforge3/envs/new_hal/lib/python3.12/site-packages/setuptools/__init__.py", line 111, in setup                                                                             
return distutils.core.setup(**attrs)                                                                                                                                                                          
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 


```
It seems the methodology for installing a python project has changed.  According to: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html.

> Starting with [PEP 621](https://peps.python.org/pep-0621/), the Python community selected pyproject.toml as a standard way of specifying project metadata.

 We can resolve this by introducing a `pyproject.toml` file here. The pyproject file for HAL uses poetry:  https://python-poetry.org/docs/pyproject/, as the backend for building the project. 

The instructions will require a slight change:
```bash
python -m pip install build
python -m pip install git+https://github.com/threeML/hawc_hal.git
```

Until the main project threeML adopts this, please use the following to upgrade an installation of `threeML` and astromodels:
```bash
pip install --upgrade git+https://github.com/threeml/threeML.git --use-pep517
pip install --upgrade git+https://github.com/threeml/astromodels.git --use-pep517
```