### PR TITLE
Updating pyproject file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,101 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "hawc_hal"
+version = "1.1"
+authors = ["Giacomo Vianello <giacomov@stanford.edu>"]
+maintainers = [
+  "Xiaojie Wang <xwang32@mtu.edu>",
+  "Ramiro Torres-Escobedo <rtorrese@proton.me>",
+]
+description = "HAWC Accelerated Likelihood; Read and handle HAWC data"
+license = "BSD-3-Clause"
+packages = [{ include = "hawc_hal" }, { include = "scripts" }]
+
+[tool.poetry.urls]
+homepage = "https://threeml.readthedocs.io/en/stable/index.html"
+repository = "https://github.com/threeML/hawc_hal"
+documentation = "https://threeml.readthedocs.io/en/stable/notebooks/hal_example.html"
+"Bug Tracker" = "https://github.com/threeML/hawc_hal/issues"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+numpy = ">=1.14"
+healpy = "*"
+threeml = "*"
+astromodels = "*"
+pandas = "*"
+pytest = "*"
+six = "*"
+astropy = "*"
+scipy = "*"
+matplotlib = "*"
+numba = "*"
+reproject = "*"
+tqdm = "*"
+uproot = "*"
+awkward = "*"
+mplhep = "*"
+hist = "*"
+ruff = "*"
+pyright = "*"
+
+
+[tool.poetry.scripts]
+hdf5tofits = "scripts.hal_hdf5_to_fits:main"
+halfitpointsrc = "scripts.hal_fit_point_source:main"
+
+[tool.ruff]
+include = [
+  "pyproject.toml",
+  "hawc_hal/**/*.py",
+  "scripts/**/*.py",
+  "notebooks/**/*.ipynb",
+]
+exclude = [
+  "codecov.yml",
+  "data/*",
+  "ci/*",
+  "notebooks",
+  "tests",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".ipynb_checkpoints",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pyenv",
+  ".pytest_cache",
+  ".pytype",
+  ".ruff_cache",
+  ".venv",
+  ".vscode",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "site-packages",
+  "venv",
+]
+line-length = 88
+indent-width = 4
+docstring-code-format = false
+
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "HAWC Accelerated Likelihood; Read and handle HAWC data"
 license = "BSD-3-Clause"
 packages = [{ include = "hawc_hal" }, { include = "scripts" }]
 
-[tool.poetry.urls]
+[tool.project.urls]
 homepage = "https://threeml.readthedocs.io/en/stable/index.html"
 repository = "https://github.com/threeML/hawc_hal"
 documentation = "https://threeml.readthedocs.io/en/stable/notebooks/hal_example.html"
@@ -84,10 +84,11 @@ exclude = [
 ]
 line-length = 88
 indent-width = 4
-docstring-code-format = false
 
 
 [tool.ruff.format]
+docstring-code-format = false
+
 # Like Black, use double quotes for strings.
 quote-style = "double"
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+line-length = 90
+target-version = "py310"
+[lint]
+select = ["F"]
+ignore = ["E501"]
+
+# [lint.isort]
+# line-after-imports = 2
+
+[format]
+quote-style = "double"
+docstring-code-format = true
+docstring-code-line-length = 60
+skip-magic-trailing-comma = true
+# quote-style = "single"


### PR DESCRIPTION
A small change to the `pyproject.toml` file to remove a deprecated file for the project url links